### PR TITLE
Fix in go get url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can download the latest binaries from [here](https://github.com/MontFerret/c
 * Go >=1.16
 
 ```bash
-go get https://github.com/MontFerret/cli
+go get github.com/MontFerret/cli
 ```
 
 ## Quick start


### PR DESCRIPTION
Current url causing `go get: malformed module path "https:/github.com/MontFerret/cli": invalid char ':'` error.