### PR TITLE
Updated installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -e
 readonly projectName="MontFerret"
 readonly appName="cli"
 readonly binName="ferret"
-readonly fullAppName="${projectName} $(echo ${appName} | awk '{print toupper(substr($0,0,1)) substr($0,2)}')"
+readonly fullAppName="Ferret CLI"
 readonly baseUrl="https://github.com/${projectName}/${appName}/releases/download"
 
 # Declare default values
@@ -74,7 +74,7 @@ detect_profile() {
   local detected_profile=""
 
   if [ "${PROFILE-}" = '/dev/null' ]; then
-    # the user has specifically requested NOT to have nvm touch their profile
+    # the user has specifically requested NOT to have us touch their profile
     return
   fi
 
@@ -96,7 +96,7 @@ detect_profile() {
   fi
 
   if [ -z "$detected_profile" ]; then
-    for profile_name in ".profile" ".bashrc" ".bash_profile" ".zshrc"; do
+    for profile_name in ".zshrc" ".bashrc" ".bash_profile" ".profile"; do
       if detected_profile="$(check_path "${HOME}/${profile_name}")"; then
         break
       fi
@@ -113,7 +113,15 @@ update_profile() {
   local location="$1"
   local profile="$(detect_profile)"
 
-  if [[ ":$PATH:" == *":$location:"* ]]; then
+  if [ -z "$profile" ]; then
+    report "No profile found. Skipping PATH update."
+    return
+  fi
+
+  report "Checking if $location is already in PATH"
+
+  if echo ":$PATH:" | grep -q ":$location:"; then
+    report "$location is already in PATH"
     return
   fi
 


### PR DESCRIPTION
This pull request includes updates to the `install.sh` script to improve usability and maintainability. The changes include simplifying variable definitions, refining profile detection logic, and enhancing feedback during the PATH update process.

### Improvements to variable definitions:
* Simplified the `fullAppName` variable by replacing the dynamic string manipulation with a static value, changing it from a computed string to `"Ferret CLI"`. (`install.sh`, [install.shL11-R11](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL11-R11))

### Refinements to profile detection logic:
* Updated a comment in the `detect_profile` function to clarify that the script avoids modifying the user's profile if explicitly requested. (`install.sh`, [install.shL77-R77](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL77-R77))
* Reordered the profile file search sequence in the `detect_profile` function to prioritize `.zshrc` over `.profile`. (`install.sh`, [install.shL99-R99](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL99-R99))

### Enhancements to PATH update process:
* Modified the `update_profile` function to handle cases where no profile is detected, providing a clear message and skipping the PATH update if necessary. Additionally, added feedback to inform users whether the specified location is already in the PATH. (`install.sh`, [install.shL116-R124](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL116-R124))