### PR TITLE
Feat/http policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,42 @@ quit            Exit
 
 The debugger currently supports local source scripts with the builtin runtime. Compiled artifacts, remote debugging, DAP, conditional breakpoints, hit-count breakpoints, and logpoints are not supported yet.
 
+## HTTP policy
+
+Ferret's builtin runtime blocks localhost, loopback, private-network, and link-local HTTP access by default. Grant only the access a script needs; for example, a script that intentionally calls a local development service requires an explicit opt-in:
+
+```bash
+ferret run \
+  --policy-http-allow-localhost \
+  --policy-http-default-headers='{"X-Trace":"local"}' \
+  script.fql
+```
+
+HTTP policy options are available on `run`, `repl`, and `debug` and apply only to the builtin runtime. Supplying one with a remote runtime is a configuration error. They configure Ferret HTTP integrations such as `IO::NET::HTTP` and `NET::REST`; the existing `--proxy` and `--user-agent` options continue to configure HTML/browser drivers.
+
+List values accept repeated flags or comma-separated values. Default headers use a JSON object with string values. Only values explicitly supplied through a flag, environment variable, or config file override Ferret's secure defaults. Numeric zero retains the Ferret default; use the dedicated `no-timeout` or `unlimited-*` option to disable a limit.
+
+| Flag and config key | Environment variable | Default | Behavior |
+| --- | --- | --- | --- |
+| `policy-http-allowed-schemes` | `FERRET_POLICY_HTTP_ALLOWED_SCHEMES` | `http,https` | Allowed URL schemes |
+| `policy-http-allowed-methods` | `FERRET_POLICY_HTTP_ALLOWED_METHODS` | `GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS` | Allowed HTTP methods |
+| `policy-http-allowed-hosts` | `FERRET_POLICY_HTTP_ALLOWED_HOSTS` | unrestricted | Exact allowed hosts or `host:port` values |
+| `policy-http-blocked-hosts` | `FERRET_POLICY_HTTP_BLOCKED_HOSTS` | none | Exact blocked hosts or `host:port` values |
+| `policy-http-allow-localhost` | `FERRET_POLICY_HTTP_ALLOW_LOCALHOST` | `false` | Allow localhost and loopback addresses |
+| `policy-http-allow-private-networks` | `FERRET_POLICY_HTTP_ALLOW_PRIVATE_NETWORKS` | `false` | Allow private-network addresses |
+| `policy-http-allow-link-local` | `FERRET_POLICY_HTTP_ALLOW_LINK_LOCAL` | `false` | Allow link-local addresses |
+| `policy-http-default-headers` | `FERRET_POLICY_HTTP_DEFAULT_HEADERS` | none | Default request headers as a JSON string map |
+| `policy-http-blocked-request-headers` | `FERRET_POLICY_HTTP_BLOCKED_REQUEST_HEADERS` | none | Block requests containing these header names |
+| `policy-http-timeout` | `FERRET_POLICY_HTTP_TIMEOUT` | `30s` | Overall HTTP timeout |
+| `policy-http-no-timeout` | `FERRET_POLICY_HTTP_NO_TIMEOUT` | `false` | Explicitly disable the overall timeout |
+| `policy-http-max-request-size` | `FERRET_POLICY_HTTP_MAX_REQUEST_SIZE` | `16777216` | Maximum request-body size in bytes |
+| `policy-http-unlimited-request-size` | `FERRET_POLICY_HTTP_UNLIMITED_REQUEST_SIZE` | `false` | Explicitly disable the request-body limit |
+| `policy-http-max-response-size` | `FERRET_POLICY_HTTP_MAX_RESPONSE_SIZE` | `16777216` | Maximum response-body size in bytes |
+| `policy-http-unlimited-response-size` | `FERRET_POLICY_HTTP_UNLIMITED_RESPONSE_SIZE` | `false` | Explicitly disable the response-body limit |
+| `policy-http-max-response-header-size` | `FERRET_POLICY_HTTP_MAX_RESPONSE_HEADER_SIZE` | `1048576` | Maximum response-header size in bytes |
+| `policy-http-follow-redirects` | `FERRET_POLICY_HTTP_FOLLOW_REDIRECTS` | `true` | Follow HTTP redirects |
+| `policy-http-max-redirects` | `FERRET_POLICY_HTTP_MAX_REDIRECTS` | `10` | Maximum redirects to follow |
+
 ## Configuration
 
 Configuration values can come from command-line flags, environment variables, or the config file.
@@ -180,6 +216,7 @@ Examples:
 ```bash
 ferret config set runtime builtin
 ferret config set browser-address http://127.0.0.1:9222
+ferret config set policy-http-allow-localhost true
 ferret config get browser-address
 ferret config list
 ```

--- a/README.md
+++ b/README.md
@@ -159,6 +159,24 @@ quit            Exit
 
 The debugger currently supports local source scripts with the builtin runtime. Compiled artifacts, remote debugging, DAP, conditional breakpoints, hit-count breakpoints, and logpoints are not supported yet.
 
+## Filesystem policy
+
+Ferret's builtin runtime exposes filesystem functions through a writable sandbox rooted at the CLI's current working directory. Select a narrower relative or absolute root, and optionally make it read-only:
+
+```bash
+ferret run \
+  --policy-fs-root=./fixtures \
+  --policy-fs-read-only \
+  script.fql
+```
+
+Filesystem policy options are available on `run`, `repl`, and `debug` and apply only to the builtin runtime. Supplying one with a remote runtime is a configuration error.
+
+| Flag and config key | Environment variable | Default | Behavior |
+| --- | --- | --- | --- |
+| `policy-fs-root` | `FERRET_POLICY_FS_ROOT` | Current working directory | Filesystem sandbox root |
+| `policy-fs-read-only` | `FERRET_POLICY_FS_READ_ONLY` | `false` | Reject writes, directory changes, and removals |
+
 ## HTTP policy
 
 Ferret's builtin runtime blocks localhost, loopback, private-network, and link-local HTTP access by default. Grant only the access a script needs; for example, a script that intentionally calls a local development service requires an explicit opt-in:
@@ -216,6 +234,8 @@ Examples:
 ```bash
 ferret config set runtime builtin
 ferret config set browser-address http://127.0.0.1:9222
+ferret config set policy-fs-root ./fixtures
+ferret config set policy-fs-read-only true
 ferret config set policy-http-allow-localhost true
 ferret config get browser-address
 ferret config list

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -39,7 +39,12 @@ artifacts, stdin, inline evaluation, remote runtimes, or conditional breakpoints
 			}
 
 			store := config.From(cmd.Context())
-			return executeDebug(cmd, store.GetRuntimeOptions(), store.GetBrowserOptions(), params, args)
+			rtOpts, err := runtimeOptionsFromCommand(cmd, store)
+			if err != nil {
+				return err
+			}
+
+			return executeDebug(cmd, rtOpts, store.GetBrowserOptions(), params, args)
 		},
 	}
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -16,6 +16,7 @@ func addRuntimeFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP(config.ExecWithBrowser, "B", false, "Open browser for script execution")
 	cmd.Flags().BoolP(config.ExecWithBrowserHeadless, "b", false, "Open browser for script execution in headless mode")
 	cmd.Flags().BoolP(config.ExecKeepCookies, "c", false, "Keep cookies between queries")
+	addHTTPPolicyFlags(cmd)
 }
 
 func addParamFlags(cmd *cobra.Command) {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,13 +9,13 @@ import (
 
 func addRuntimeFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(config.ExecRuntime, "r", cliruntime.DefaultRuntime, "Ferret runtime type (\"builtin\"|$url)")
-	cmd.Flags().String(config.ExecRuntimeFSRoot, "Current working directory", "Ferret runtime file system root")
 	cmd.Flags().String(config.ExecProxy, "x", "Proxy server address")
 	cmd.Flags().String(config.ExecUserAgent, "a", "User agent header")
 	cmd.Flags().StringP(config.ExecBrowserAddress, "d", cliruntime.DefaultBrowser, "Browser debugger address")
 	cmd.Flags().BoolP(config.ExecWithBrowser, "B", false, "Open browser for script execution")
 	cmd.Flags().BoolP(config.ExecWithBrowserHeadless, "b", false, "Open browser for script execution in headless mode")
 	cmd.Flags().BoolP(config.ExecKeepCookies, "c", false, "Keep cookies between queries")
+	addFSPolicyFlags(cmd)
 	addHTTPPolicyFlags(cmd)
 }
 

--- a/cmd/fs_policy.go
+++ b/cmd/fs_policy.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+)
+
+func addFSPolicyFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.String(config.PolicyFSRoot, "", "Filesystem root directory for the builtin runtime")
+	flags.Bool(config.PolicyFSReadOnly, false, "Make the builtin runtime filesystem read-only")
+}
+
+func fsPolicyFromCommand(cmd *cobra.Command) (*cliruntime.FileSystemPolicy, error) {
+	if cmd == nil {
+		return nil, nil
+	}
+
+	flags := cmd.Flags()
+	rootSet := flags.Changed(config.PolicyFSRoot)
+	readOnlySet := flags.Changed(config.PolicyFSReadOnly)
+	if !rootSet && !readOnlySet {
+		return nil, nil
+	}
+
+	policy := &cliruntime.FileSystemPolicy{}
+
+	if rootSet {
+		root, err := flags.GetString(config.PolicyFSRoot)
+		if err != nil {
+			return nil, err
+		}
+
+		policy.Root = strings.TrimSpace(root)
+		if policy.Root == "" {
+			return nil, fmt.Errorf("--%s cannot be empty", config.PolicyFSRoot)
+		}
+	}
+
+	if readOnlySet {
+		readOnly, err := flags.GetBool(config.PolicyFSReadOnly)
+		if err != nil {
+			return nil, err
+		}
+
+		policy.ReadOnly = readOnly
+	}
+
+	return policy, nil
+}

--- a/cmd/fs_policy_test.go
+++ b/cmd/fs_policy_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+
+	"github.com/MontFerret/cli/v2/pkg/browser"
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+var fsPolicyFlagNames = []string{
+	config.PolicyFSRoot,
+	config.PolicyFSReadOnly,
+}
+
+func TestFSPolicyFlagsAppearOnExecutionCommands(t *testing.T) {
+	store := new(config.Store)
+	commands := []*cobra.Command{
+		RunCommand(store),
+		ReplCommand(store),
+		DebugCommand(store),
+	}
+
+	for _, command := range commands {
+		t.Run(command.Name(), func(t *testing.T) {
+			var output bytes.Buffer
+			command.SetOut(&output)
+			command.SetErr(&output)
+
+			if err := command.Help(); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, name := range fsPolicyFlagNames {
+				if command.Flags().Lookup(name) == nil {
+					t.Fatalf("expected --%s to be registered", name)
+				}
+				if !strings.Contains(output.String(), "--"+name) {
+					t.Fatalf("expected help to list --%s", name)
+				}
+			}
+
+			if command.Flags().Lookup("runtime-fs-root") != nil {
+				t.Fatal("expected --runtime-fs-root to be removed")
+			}
+		})
+	}
+}
+
+func TestFSPolicyFlagsDoNotAppearOnVersion(t *testing.T) {
+	command := VersionCommand(new(config.Store))
+
+	for _, name := range fsPolicyFlagNames {
+		if command.Flags().Lookup(name) != nil {
+			t.Fatalf("expected --%s to be absent", name)
+		}
+	}
+}
+
+func TestFSPolicyFlagDefaultsDoNotCreateExplicitPolicy(t *testing.T) {
+	command := &cobra.Command{Use: "policy-test"}
+	addFSPolicyFlags(command)
+
+	policy, err := fsPolicyFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy != nil {
+		t.Fatalf("expected no explicit filesystem policy, got %#v", policy)
+	}
+}
+
+func TestFSPolicyFlagValuesReachRuntimeOptions(t *testing.T) {
+	command := &cobra.Command{Use: "policy-test"}
+	addFSPolicyFlags(command)
+	if err := command.Flags().Parse([]string{"--policy-fs-root= ./fixtures ", "--policy-fs-read-only"}); err != nil {
+		t.Fatal(err)
+	}
+
+	policy, err := fsPolicyFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy == nil || policy.Root != "./fixtures" || !policy.ReadOnly {
+		t.Fatalf("unexpected filesystem policy: %#v", policy)
+	}
+}
+
+func TestFSPolicyFlagsRejectExplicitBlankRoot(t *testing.T) {
+	command := &cobra.Command{Use: "policy-test"}
+	addFSPolicyFlags(command)
+	if err := command.Flags().Parse([]string{"--policy-fs-root= \t "}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := fsPolicyFromCommand(command)
+	if err == nil || err.Error() != "--policy-fs-root cannot be empty" {
+		t.Fatalf("expected blank root error, got %v", err)
+	}
+}
+
+func TestFSPolicyEnvironmentValuesReachBuiltinRuntime(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.txt"), []byte("fixture"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FERRET_POLICY_FS_ROOT", root)
+	t.Setenv("FERRET_POLICY_FS_READ_ONLY", "true")
+
+	store := newFSPolicyTestStore(t, t.TempDir())
+	command := RunCommand(store)
+	store.BindFlags(command)
+
+	opts, err := runtimeOptionsFromCommand(command, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.FSPolicy == nil || opts.FSPolicy.Root != root || !opts.FSPolicy.ReadOnly {
+		t.Fatalf("unexpected filesystem policy: %#v", opts.FSPolicy)
+	}
+
+	out, err := cliruntime.Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(`RETURN TO_STRING(IO::FS::READ("fixture.txt"))`),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+}
+
+func TestFSPolicyConfigValuesReachRuntimeOptions(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	store := newFSPolicyTestStore(t, home)
+	if err := store.Set(config.PolicyFSRoot, root); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(config.PolicyFSReadOnly, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	homedir.Reset()
+	store = newFSPolicyTestStore(t, home)
+	command := RunCommand(store)
+	store.BindFlags(command)
+
+	opts, err := runtimeOptionsFromCommand(command, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.FSPolicy == nil || opts.FSPolicy.Root != root || !opts.FSPolicy.ReadOnly {
+		t.Fatalf("unexpected filesystem policy: %#v", opts.FSPolicy)
+	}
+}
+
+func TestLegacyRuntimeFSRootFlagIsRejected(t *testing.T) {
+	command := RunCommand(new(config.Store))
+
+	err := command.Flags().Parse([]string{"--runtime-fs-root=."})
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --runtime-fs-root") {
+		t.Fatalf("expected legacy flag rejection, got %v", err)
+	}
+}
+
+func TestLegacyRuntimeFSRootEnvironmentIsIgnored(t *testing.T) {
+	t.Setenv("FERRET_RUNTIME_FS_ROOT", t.TempDir())
+
+	store := newFSPolicyTestStore(t, t.TempDir())
+	command := RunCommand(store)
+	store.BindFlags(command)
+
+	opts, err := runtimeOptionsFromCommand(command, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.FSPolicy != nil {
+		t.Fatalf("expected legacy environment variable to be ignored, got %#v", opts.FSPolicy)
+	}
+}
+
+func TestExecuteRun_FSPolicyRemoteRuntimeRejectedBeforeBrowserStartup(t *testing.T) {
+	opts := cliruntime.NewDefaultOptions()
+	opts.Type = "https://worker.example"
+	opts.WithBrowser = true
+	opts.BrowserAddress = "://invalid"
+	opts.FSPolicy = &cliruntime.FileSystemPolicy{ReadOnly: true}
+
+	err := executeRun(
+		newTestCommand(),
+		opts,
+		browser.Options{},
+		nil,
+		"RETURN 1",
+		nil,
+	)
+	if !errors.Is(err, cliruntime.ErrFSPolicyRequiresBuiltinRuntime) {
+		t.Fatalf("expected builtin runtime policy error, got %v", err)
+	}
+}
+
+func newFSPolicyTestStore(t *testing.T, home string) *config.Store {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := config.NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return store
+}

--- a/cmd/http_policy.go
+++ b/cmd/http_policy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/MontFerret/cli/v2/pkg/config"
-	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
 	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 )
 
@@ -41,19 +40,6 @@ func addHTTPPolicyFlags(cmd *cobra.Command) {
 	flags.Int64(config.PolicyHTTPMaxResponseHeaderSize, defaultHTTPPolicyMaxHeaderSize, "Maximum outbound HTTP response header size in bytes")
 	flags.Bool(config.PolicyHTTPFollowRedirects, true, "Follow outbound HTTP redirects")
 	flags.Int(config.PolicyHTTPMaxRedirects, defaultHTTPPolicyMaxRedirects, "Maximum number of outbound HTTP redirects")
-}
-
-func runtimeOptionsFromCommand(cmd *cobra.Command, store *config.Store) (cliruntime.Options, error) {
-	opts := store.GetRuntimeOptions()
-
-	policy, err := httpPolicyOptionsFromCommand(cmd)
-	if err != nil {
-		return cliruntime.Options{}, err
-	}
-
-	opts.HTTPPolicy = policy
-
-	return opts, nil
 }
 
 func httpPolicyOptionsFromCommand(cmd *cobra.Command) ([]ferrethttp.PolicyOption, error) {

--- a/cmd/http_policy.go
+++ b/cmd/http_policy.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+)
+
+const (
+	defaultHTTPPolicyTimeout               = 30 * time.Second
+	defaultHTTPPolicyMaxRequestSize  int64 = 16 << 20
+	defaultHTTPPolicyMaxResponseSize int64 = 16 << 20
+	defaultHTTPPolicyMaxHeaderSize   int64 = 1 << 20
+	defaultHTTPPolicyMaxRedirects          = 10
+)
+
+func addHTTPPolicyFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.StringSlice(config.PolicyHTTPAllowedSchemes, []string{"http", "https"}, "Allowed outbound HTTP URL schemes")
+	flags.StringSlice(config.PolicyHTTPAllowedMethods, []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}, "Allowed outbound HTTP methods")
+	flags.StringSlice(config.PolicyHTTPAllowedHosts, nil, "Allowed outbound HTTP hosts (exact host or host:port)")
+	flags.StringSlice(config.PolicyHTTPBlockedHosts, nil, "Blocked outbound HTTP hosts (exact host or host:port)")
+	flags.Bool(config.PolicyHTTPAllowLocalhost, false, "Allow outbound HTTP access to localhost and loopback addresses")
+	flags.Bool(config.PolicyHTTPAllowPrivateNetworks, false, "Allow outbound HTTP access to private network addresses")
+	flags.Bool(config.PolicyHTTPAllowLinkLocal, false, "Allow outbound HTTP access to link-local addresses")
+	flags.String(config.PolicyHTTPDefaultHeaders, "", "Default outbound HTTP headers as a JSON object")
+	flags.StringSlice(config.PolicyHTTPBlockedRequestHeaders, nil, "Blocked outbound HTTP request header names")
+	flags.Duration(config.PolicyHTTPTimeout, defaultHTTPPolicyTimeout, "Overall outbound HTTP timeout")
+	flags.Bool(config.PolicyHTTPNoTimeout, false, "Disable the overall outbound HTTP timeout")
+	flags.Int64(config.PolicyHTTPMaxRequestSize, defaultHTTPPolicyMaxRequestSize, "Maximum outbound HTTP request body size in bytes")
+	flags.Bool(config.PolicyHTTPUnlimitedRequestSize, false, "Disable the outbound HTTP request body size limit")
+	flags.Int64(config.PolicyHTTPMaxResponseSize, defaultHTTPPolicyMaxResponseSize, "Maximum outbound HTTP response body size in bytes")
+	flags.Bool(config.PolicyHTTPUnlimitedResponseSize, false, "Disable the outbound HTTP response body size limit")
+	flags.Int64(config.PolicyHTTPMaxResponseHeaderSize, defaultHTTPPolicyMaxHeaderSize, "Maximum outbound HTTP response header size in bytes")
+	flags.Bool(config.PolicyHTTPFollowRedirects, true, "Follow outbound HTTP redirects")
+	flags.Int(config.PolicyHTTPMaxRedirects, defaultHTTPPolicyMaxRedirects, "Maximum number of outbound HTTP redirects")
+}
+
+func runtimeOptionsFromCommand(cmd *cobra.Command, store *config.Store) (cliruntime.Options, error) {
+	opts := store.GetRuntimeOptions()
+
+	policy, err := httpPolicyOptionsFromCommand(cmd)
+	if err != nil {
+		return cliruntime.Options{}, err
+	}
+
+	opts.HTTPPolicy = policy
+
+	return opts, nil
+}
+
+func httpPolicyOptionsFromCommand(cmd *cobra.Command) ([]ferrethttp.PolicyOption, error) {
+	if cmd == nil {
+		return nil, nil
+	}
+
+	flags := cmd.Flags()
+
+	noTimeout, err := flags.GetBool(config.PolicyHTTPNoTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if noTimeout && flags.Changed(config.PolicyHTTPTimeout) {
+		return nil, fmt.Errorf("--%s cannot be combined with --%s", config.PolicyHTTPNoTimeout, config.PolicyHTTPTimeout)
+	}
+
+	unlimitedRequest, err := flags.GetBool(config.PolicyHTTPUnlimitedRequestSize)
+	if err != nil {
+		return nil, err
+	}
+	if unlimitedRequest && flags.Changed(config.PolicyHTTPMaxRequestSize) {
+		return nil, fmt.Errorf("--%s cannot be combined with --%s", config.PolicyHTTPUnlimitedRequestSize, config.PolicyHTTPMaxRequestSize)
+	}
+
+	unlimitedResponse, err := flags.GetBool(config.PolicyHTTPUnlimitedResponseSize)
+	if err != nil {
+		return nil, err
+	}
+	if unlimitedResponse && flags.Changed(config.PolicyHTTPMaxResponseSize) {
+		return nil, fmt.Errorf("--%s cannot be combined with --%s", config.PolicyHTTPUnlimitedResponseSize, config.PolicyHTTPMaxResponseSize)
+	}
+
+	var options []ferrethttp.PolicyOption
+
+	if flags.Changed(config.PolicyHTTPAllowedSchemes) {
+		value, err := flags.GetStringSlice(config.PolicyHTTPAllowedSchemes)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithAllowedSchemes(value...))
+	}
+
+	if flags.Changed(config.PolicyHTTPAllowedMethods) {
+		value, err := flags.GetStringSlice(config.PolicyHTTPAllowedMethods)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithAllowedMethods(value...))
+	}
+
+	if flags.Changed(config.PolicyHTTPAllowedHosts) {
+		value, err := flags.GetStringSlice(config.PolicyHTTPAllowedHosts)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithAllowedHosts(value...))
+	}
+
+	if flags.Changed(config.PolicyHTTPBlockedHosts) {
+		value, err := flags.GetStringSlice(config.PolicyHTTPBlockedHosts)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithBlockedHosts(value...))
+	}
+
+	if flags.Changed(config.PolicyHTTPAllowLocalhost) {
+		value, err := flags.GetBool(config.PolicyHTTPAllowLocalhost)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithAllowLocalhost(value))
+	}
+
+	if flags.Changed(config.PolicyHTTPAllowPrivateNetworks) {
+		value, err := flags.GetBool(config.PolicyHTTPAllowPrivateNetworks)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithAllowPrivateNetworks(value))
+	}
+
+	if flags.Changed(config.PolicyHTTPAllowLinkLocal) {
+		value, err := flags.GetBool(config.PolicyHTTPAllowLinkLocal)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithAllowLinkLocal(value))
+	}
+
+	if flags.Changed(config.PolicyHTTPDefaultHeaders) {
+		value, err := flags.GetString(config.PolicyHTTPDefaultHeaders)
+		if err != nil {
+			return nil, err
+		}
+
+		headers := make(map[string]string)
+		if err := json.Unmarshal([]byte(value), &headers); err != nil {
+			return nil, fmt.Errorf("invalid --%s: expected a JSON object of string values: %w", config.PolicyHTTPDefaultHeaders, err)
+		}
+		if headers == nil {
+			return nil, fmt.Errorf("invalid --%s: expected a JSON object of string values", config.PolicyHTTPDefaultHeaders)
+		}
+
+		options = append(options, ferrethttp.WithDefaultHeaders(headers))
+	}
+
+	if flags.Changed(config.PolicyHTTPBlockedRequestHeaders) {
+		value, err := flags.GetStringSlice(config.PolicyHTTPBlockedRequestHeaders)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithBlockedRequestHeaders(value...))
+	}
+
+	if noTimeout {
+		options = append(options, ferrethttp.WithNoTimeout())
+	} else if flags.Changed(config.PolicyHTTPTimeout) {
+		value, err := flags.GetDuration(config.PolicyHTTPTimeout)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithTimeout(value))
+	} else if flags.Changed(config.PolicyHTTPNoTimeout) {
+		options = append(options, ferrethttp.WithTimeout(0))
+	}
+
+	if unlimitedRequest {
+		options = append(options, ferrethttp.WithUnlimitedRequestSize())
+	} else if flags.Changed(config.PolicyHTTPMaxRequestSize) {
+		value, err := flags.GetInt64(config.PolicyHTTPMaxRequestSize)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithMaxRequestSize(value))
+	} else if flags.Changed(config.PolicyHTTPUnlimitedRequestSize) {
+		options = append(options, ferrethttp.WithMaxRequestSize(0))
+	}
+
+	if unlimitedResponse {
+		options = append(options, ferrethttp.WithUnlimitedResponseSize())
+	} else if flags.Changed(config.PolicyHTTPMaxResponseSize) {
+		value, err := flags.GetInt64(config.PolicyHTTPMaxResponseSize)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithMaxResponseSize(value))
+	} else if flags.Changed(config.PolicyHTTPUnlimitedResponseSize) {
+		options = append(options, ferrethttp.WithMaxResponseSize(0))
+	}
+
+	if flags.Changed(config.PolicyHTTPMaxResponseHeaderSize) {
+		value, err := flags.GetInt64(config.PolicyHTTPMaxResponseHeaderSize)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithMaxResponseHeaderSize(value))
+	}
+
+	if flags.Changed(config.PolicyHTTPFollowRedirects) {
+		value, err := flags.GetBool(config.PolicyHTTPFollowRedirects)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithFollowRedirects(value))
+	}
+
+	if flags.Changed(config.PolicyHTTPMaxRedirects) {
+		value, err := flags.GetInt(config.PolicyHTTPMaxRedirects)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, ferrethttp.WithMaxRedirects(value))
+	}
+
+	return options, nil
+}

--- a/cmd/http_policy_test.go
+++ b/cmd/http_policy_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+var httpPolicyFlagNames = []string{
+	config.PolicyHTTPAllowedSchemes,
+	config.PolicyHTTPAllowedMethods,
+	config.PolicyHTTPAllowedHosts,
+	config.PolicyHTTPBlockedHosts,
+	config.PolicyHTTPAllowLocalhost,
+	config.PolicyHTTPAllowPrivateNetworks,
+	config.PolicyHTTPAllowLinkLocal,
+	config.PolicyHTTPDefaultHeaders,
+	config.PolicyHTTPBlockedRequestHeaders,
+	config.PolicyHTTPTimeout,
+	config.PolicyHTTPNoTimeout,
+	config.PolicyHTTPMaxRequestSize,
+	config.PolicyHTTPUnlimitedRequestSize,
+	config.PolicyHTTPMaxResponseSize,
+	config.PolicyHTTPUnlimitedResponseSize,
+	config.PolicyHTTPMaxResponseHeaderSize,
+	config.PolicyHTTPFollowRedirects,
+	config.PolicyHTTPMaxRedirects,
+}
+
+func TestHTTPPolicyFlagsAppearOnExecutionCommands(t *testing.T) {
+	store := new(config.Store)
+	commands := []*cobra.Command{
+		RunCommand(store),
+		ReplCommand(store),
+		DebugCommand(store),
+	}
+
+	for _, command := range commands {
+		t.Run(command.Name(), func(t *testing.T) {
+			var output bytes.Buffer
+			command.SetOut(&output)
+			command.SetErr(&output)
+
+			if err := command.Help(); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, name := range httpPolicyFlagNames {
+				if command.Flags().Lookup(name) == nil {
+					t.Fatalf("expected --%s to be registered", name)
+				}
+				if !strings.Contains(output.String(), "--"+name) {
+					t.Fatalf("expected help to list --%s", name)
+				}
+			}
+		})
+	}
+}
+
+func TestHTTPPolicyFlagsDoNotAppearOnVersion(t *testing.T) {
+	command := VersionCommand(new(config.Store))
+
+	for _, name := range httpPolicyFlagNames {
+		if command.Flags().Lookup(name) != nil {
+			t.Fatalf("expected --%s to be absent", name)
+		}
+	}
+}
+
+func TestHTTPPolicyFlagDefaultsDoNotOverrideFerretDefaults(t *testing.T) {
+	command := &cobra.Command{Use: "policy-test"}
+	addHTTPPolicyFlags(command)
+
+	options, err := httpPolicyOptionsFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("expected no explicit HTTP policy options, got %d", len(options))
+	}
+}
+
+func TestHTTPPolicyFlagsRejectInvalidFerretPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "allowed scheme", arg: "--policy-http-allowed-schemes=not a scheme", want: "WithAllowedSchemes"},
+		{name: "allowed method", arg: "--policy-http-allowed-methods=bad method", want: "WithAllowedMethods"},
+		{name: "allowed host", arg: "--policy-http-allowed-hosts=bad host", want: "WithAllowedHosts"},
+		{name: "blocked host", arg: "--policy-http-blocked-hosts=bad host", want: "WithBlockedHosts"},
+		{name: "default header", arg: `--policy-http-default-headers={"Host":"example.test"}`, want: "WithDefaultHeaders"},
+		{name: "blocked header", arg: "--policy-http-blocked-request-headers=bad header", want: "WithBlockedRequestHeaders"},
+		{name: "timeout", arg: "--policy-http-timeout=-1s", want: "WithTimeout"},
+		{name: "request size", arg: "--policy-http-max-request-size=-1", want: "WithMaxRequestSize"},
+		{name: "response size", arg: "--policy-http-max-response-size=-1", want: "WithMaxResponseSize"},
+		{name: "response header size", arg: "--policy-http-max-response-header-size=-1", want: "WithMaxResponseHeaderSize"},
+		{name: "redirect count", arg: "--policy-http-max-redirects=-1", want: "WithMaxRedirects"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPPolicyArguments(t, tt.arg)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %s error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestHTTPPolicyFlagsRejectConflictingLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "timeout",
+			args: []string{"--policy-http-timeout=1s", "--policy-http-no-timeout"},
+			want: "--policy-http-no-timeout cannot be combined with --policy-http-timeout",
+		},
+		{
+			name: "request size",
+			args: []string{"--policy-http-max-request-size=1", "--policy-http-unlimited-request-size"},
+			want: "--policy-http-unlimited-request-size cannot be combined with --policy-http-max-request-size",
+		},
+		{
+			name: "response size",
+			args: []string{"--policy-http-max-response-size=1", "--policy-http-unlimited-response-size"},
+			want: "--policy-http-unlimited-response-size cannot be combined with --policy-http-max-response-size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPPolicyArguments(t, tt.args...)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestHTTPPolicyFlagsRejectInvalidDefaultHeadersJSON(t *testing.T) {
+	err := validateHTTPPolicyArguments(t, `--policy-http-default-headers={"X-Trace":1}`)
+	if err == nil || !strings.Contains(err.Error(), "expected a JSON object of string values") {
+		t.Fatalf("expected default-header JSON error, got %v", err)
+	}
+}
+
+func TestHTTPPolicyEnvironmentValuesReachBuiltinRuntime(t *testing.T) {
+	t.Setenv("FERRET_POLICY_HTTP_ALLOW_LOCALHOST", "true")
+	t.Setenv("FERRET_POLICY_HTTP_DEFAULT_HEADERS", `{"X-Ferret-Policy":"environment"}`)
+
+	store := newHTTPPolicyTestStore(t, t.TempDir())
+	command := RunCommand(store)
+	store.BindFlags(command)
+
+	opts, err := runtimeOptionsFromCommand(command, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Get("X-Ferret-Policy")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	out, err := cliruntime.Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(fmt.Sprintf("RETURN TO_STRING(IO::NET::HTTP::GET(%q))", server.URL)),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	if got := <-requests; got != "environment" {
+		t.Fatalf("expected environment default header, got %q", got)
+	}
+}
+
+func TestHTTPPolicyFlagValuesReachBuiltinRuntime(t *testing.T) {
+	command := &cobra.Command{Use: "policy-test"}
+	addHTTPPolicyFlags(command)
+	if err := command.Flags().Parse([]string{
+		"--policy-http-allow-localhost",
+		`--policy-http-default-headers={"X-Ferret-Policy":"flag"}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	policy, err := httpPolicyOptionsFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := cliruntime.NewDefaultOptions()
+	opts.HTTPPolicy = policy
+
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Get("X-Ferret-Policy")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	out, err := cliruntime.Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(fmt.Sprintf("RETURN TO_STRING(IO::NET::HTTP::GET(%q))", server.URL)),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	if got := <-requests; got != "flag" {
+		t.Fatalf("expected flag default header, got %q", got)
+	}
+}
+
+func TestHTTPPolicyConfigValuesReachRuntimeOptions(t *testing.T) {
+	home := t.TempDir()
+	store := newHTTPPolicyTestStore(t, home)
+	if err := store.Set(config.PolicyHTTPAllowLocalhost, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(config.PolicyHTTPAllowedMethods, "GET,POST"); err != nil {
+		t.Fatal(err)
+	}
+
+	homedir.Reset()
+	store = newHTTPPolicyTestStore(t, home)
+	command := RunCommand(store)
+	store.BindFlags(command)
+
+	opts, err := runtimeOptionsFromCommand(command, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.HTTPPolicy) != 2 {
+		t.Fatalf("expected two configured HTTP policy options, got %d", len(opts.HTTPPolicy))
+	}
+	if err := cliruntime.ValidateOptions(opts); err != nil {
+		t.Fatalf("expected configured policy to validate, got %v", err)
+	}
+}
+
+func validateHTTPPolicyArguments(t *testing.T, args ...string) error {
+	t.Helper()
+
+	command := &cobra.Command{Use: "policy-test"}
+	addHTTPPolicyFlags(command)
+
+	if err := command.Flags().Parse(args); err != nil {
+		return err
+	}
+
+	options, err := httpPolicyOptionsFromCommand(command)
+	if err != nil {
+		return err
+	}
+
+	runtimeOptions := cliruntime.NewDefaultOptions()
+	runtimeOptions.HTTPPolicy = options
+
+	return cliruntime.ValidateOptions(runtimeOptions)
+}
+
+func newHTTPPolicyTestStore(t *testing.T, home string) *config.Store {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := config.NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return store
+}

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -30,7 +30,10 @@ func ReplCommand(store *config.Store) *cobra.Command {
 			}
 
 			store := config.From(cmd.Context())
-			rtOpts := store.GetRuntimeOptions()
+			rtOpts, err := runtimeOptionsFromCommand(cmd, store)
+			if err != nil {
+				return err
+			}
 
 			cleanup, err := browser.EnsureBrowser(cmd.Context(), rtOpts, store.GetBrowserOptions())
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,7 +46,12 @@ func RunCommand(store *config.Store) *cobra.Command {
 			}
 
 			store := config.From(cmd.Context())
-			return executeRun(cmd, store.GetRuntimeOptions(), store.GetBrowserOptions(), params, eval, args)
+			rtOpts, err := runtimeOptionsFromCommand(cmd, store)
+			if err != nil {
+				return err
+			}
+
+			return executeRun(cmd, rtOpts, store.GetBrowserOptions(), params, eval, args)
 		},
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MontFerret/cli/v2/pkg/logger"
 	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
@@ -90,6 +91,26 @@ func TestExecuteRun_ArtifactStdinRemoteRuntimeRejected(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestExecuteRun_HTTPPolicyRemoteRuntimeRejectedBeforeBrowserStartup(t *testing.T) {
+	opts := cliruntime.NewDefaultOptions()
+	opts.Type = "https://worker.example"
+	opts.WithBrowser = true
+	opts.BrowserAddress = "://invalid"
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{ferrethttp.WithAllowLocalhost(true)}
+
+	err := executeRun(
+		newTestCommand(),
+		opts,
+		browser.Options{},
+		nil,
+		"RETURN 1",
+		nil,
+	)
+	if !errors.Is(err, cliruntime.ErrHTTPPolicyRequiresBuiltinRuntime) {
+		t.Fatalf("expected builtin runtime policy error, got %v", err)
+	}
 }
 
 func TestRunCommand_RejectsMultiplePositionalArgs(t *testing.T) {

--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+)
+
+func runtimeOptionsFromCommand(cmd *cobra.Command, store *config.Store) (cliruntime.Options, error) {
+	opts := store.GetRuntimeOptions()
+
+	httpPolicy, err := httpPolicyOptionsFromCommand(cmd)
+	if err != nil {
+		return cliruntime.Options{}, err
+	}
+	opts.HTTPPolicy = httpPolicy
+
+	fsPolicy, err := fsPolicyFromCommand(cmd)
+	if err != nil {
+		return cliruntime.Options{}, err
+	}
+	opts.FSPolicy = fsPolicy
+
+	return opts, nil
+}

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -16,6 +16,25 @@ const (
 	ExecProxy               = "proxy"
 	ExecUserAgent           = "user-agent"
 
+	PolicyHTTPAllowedSchemes        = "policy-http-allowed-schemes"
+	PolicyHTTPAllowedMethods        = "policy-http-allowed-methods"
+	PolicyHTTPAllowedHosts          = "policy-http-allowed-hosts"
+	PolicyHTTPBlockedHosts          = "policy-http-blocked-hosts"
+	PolicyHTTPAllowLocalhost        = "policy-http-allow-localhost"
+	PolicyHTTPAllowPrivateNetworks  = "policy-http-allow-private-networks"
+	PolicyHTTPAllowLinkLocal        = "policy-http-allow-link-local"
+	PolicyHTTPDefaultHeaders        = "policy-http-default-headers"
+	PolicyHTTPBlockedRequestHeaders = "policy-http-blocked-request-headers"
+	PolicyHTTPTimeout               = "policy-http-timeout"
+	PolicyHTTPNoTimeout             = "policy-http-no-timeout"
+	PolicyHTTPMaxRequestSize        = "policy-http-max-request-size"
+	PolicyHTTPUnlimitedRequestSize  = "policy-http-unlimited-request-size"
+	PolicyHTTPMaxResponseSize       = "policy-http-max-response-size"
+	PolicyHTTPUnlimitedResponseSize = "policy-http-unlimited-response-size"
+	PolicyHTTPMaxResponseHeaderSize = "policy-http-max-response-header-size"
+	PolicyHTTPFollowRedirects       = "policy-http-follow-redirects"
+	PolicyHTTPMaxRedirects          = "policy-http-max-redirects"
+
 	BrowserPort     = "port"
 	BrowserDetach   = "detach"
 	BrowserHeadless = "headless"
@@ -34,6 +53,24 @@ var Flags = []string{
 	ExecWithBrowserHeadless,
 	ExecProxy,
 	ExecUserAgent,
+	PolicyHTTPAllowedSchemes,
+	PolicyHTTPAllowedMethods,
+	PolicyHTTPAllowedHosts,
+	PolicyHTTPBlockedHosts,
+	PolicyHTTPAllowLocalhost,
+	PolicyHTTPAllowPrivateNetworks,
+	PolicyHTTPAllowLinkLocal,
+	PolicyHTTPDefaultHeaders,
+	PolicyHTTPBlockedRequestHeaders,
+	PolicyHTTPTimeout,
+	PolicyHTTPNoTimeout,
+	PolicyHTTPMaxRequestSize,
+	PolicyHTTPUnlimitedRequestSize,
+	PolicyHTTPMaxResponseSize,
+	PolicyHTTPUnlimitedResponseSize,
+	PolicyHTTPMaxResponseHeaderSize,
+	PolicyHTTPFollowRedirects,
+	PolicyHTTPMaxRedirects,
 }
 var FlagsStr = strings.Join(Flags, `"|"`)
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -8,7 +8,6 @@ const (
 	LoggerFile   = "log-file"
 
 	ExecRuntime             = "runtime"
-	ExecRuntimeFSRoot       = "runtime-fs-root"
 	ExecKeepCookies         = "browser-cookies"
 	ExecWithBrowser         = "browser-open"
 	ExecBrowserAddress      = "browser-address"
@@ -16,6 +15,8 @@ const (
 	ExecProxy               = "proxy"
 	ExecUserAgent           = "user-agent"
 
+	PolicyFSRoot                    = "policy-fs-root"
+	PolicyFSReadOnly                = "policy-fs-read-only"
 	PolicyHTTPAllowedSchemes        = "policy-http-allowed-schemes"
 	PolicyHTTPAllowedMethods        = "policy-http-allowed-methods"
 	PolicyHTTPAllowedHosts          = "policy-http-allowed-hosts"
@@ -46,13 +47,14 @@ var Flags = []string{
 	LoggerOutput,
 	LoggerFile,
 	ExecRuntime,
-	ExecRuntimeFSRoot,
 	ExecKeepCookies,
 	ExecBrowserAddress,
 	ExecWithBrowser,
 	ExecWithBrowserHeadless,
 	ExecProxy,
 	ExecUserAgent,
+	PolicyFSRoot,
+	PolicyFSReadOnly,
 	PolicyHTTPAllowedSchemes,
 	PolicyHTTPAllowedMethods,
 	PolicyHTTPAllowedHosts,

--- a/pkg/config/fs_policy_test.go
+++ b/pkg/config/fs_policy_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func TestFilesystemPolicyConfigKeysReplaceRuntimeFSRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Set(PolicyFSRoot, "./fixtures"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(PolicyFSReadOnly, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Get(PolicyFSRoot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(PolicyFSReadOnly); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("runtime-fs-root", "./legacy"); !errors.Is(err, ErrInvalidFlag) {
+		t.Fatalf("expected legacy config key rejection, got %v", err)
+	}
+	if _, err := store.Get("runtime-fs-root"); !errors.Is(err, ErrInvalidFlag) {
+		t.Fatalf("expected legacy config key lookup rejection, got %v", err)
+	}
+
+	seen := make(map[string]bool)
+	for _, entry := range store.List() {
+		seen[entry.Key] = true
+	}
+
+	if !seen[PolicyFSRoot] || !seen[PolicyFSReadOnly] {
+		t.Fatalf("expected filesystem policy keys in config list: %#v", seen)
+	}
+	if seen["runtime-fs-root"] {
+		t.Fatal("expected runtime-fs-root to be removed from config list")
+	}
+}

--- a/pkg/runtime/builtin.go
+++ b/pkg/runtime/builtin.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/MontFerret/cli/v2/pkg/logger"
 	"github.com/MontFerret/ferret/v2"
@@ -32,6 +33,19 @@ func NewBuiltin(opts Options) (Runtime, error) {
 }
 
 func newBuiltin(opts Options) (*Builtin, error) {
+	fsRoot := ""
+	if opts.FSPolicy != nil {
+		fsRoot = opts.FSPolicy.Root
+	}
+
+	if fsRoot == "" {
+		var err error
+		fsRoot, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("resolve filesystem root: %w", err)
+		}
+	}
+
 	mods, err := newModules(opts)
 
 	if err != nil {
@@ -46,6 +60,11 @@ func newBuiltin(opts Options) (*Builtin, error) {
 
 	engineOpts := []ferret.Option{
 		ferret.WithModules(mods...),
+		ferret.WithFSRoot(fsRoot),
+	}
+
+	if opts.FSPolicy != nil && opts.FSPolicy.ReadOnly {
+		engineOpts = append(engineOpts, ferret.WithFSReadOnly())
 	}
 
 	if log.Output() != nil {

--- a/pkg/runtime/builtin.go
+++ b/pkg/runtime/builtin.go
@@ -10,6 +10,8 @@ import (
 	"github.com/MontFerret/cli/v2/pkg/logger"
 	"github.com/MontFerret/ferret/v2"
 	"github.com/MontFerret/ferret/v2/pkg/logging"
+	ferretnet "github.com/MontFerret/ferret/v2/pkg/net"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
@@ -19,9 +21,10 @@ const DefaultRuntime = "builtin"
 const DefaultBrowser = "http://127.0.0.1:9222"
 
 type Builtin struct {
-	opts   Options
-	engine *ferret.Engine
-	logger *logger.Logger
+	opts    Options
+	engine  *ferret.Engine
+	logger  *logger.Logger
+	network ferretnet.Network
 }
 
 func NewBuiltin(opts Options) (Runtime, error) {
@@ -53,17 +56,44 @@ func newBuiltin(opts Options) (*Builtin, error) {
 		)
 	}
 
+	var network ferretnet.Network
+
+	if len(opts.HTTPPolicy) > 0 {
+		client, err := ferrethttp.New(opts.HTTPPolicy...)
+		if err != nil {
+			_ = log.Close()
+			return nil, fmt.Errorf("initialize HTTP policy: %w", err)
+		}
+
+		network, err = ferretnet.New(ferretnet.WithHTTPClient(client))
+		if err != nil {
+			if closer, ok := client.(ferrethttp.IdleConnectionCloser); ok {
+				closer.CloseIdleConnections()
+			}
+
+			_ = log.Close()
+			return nil, fmt.Errorf("initialize network: %w", err)
+		}
+
+		engineOpts = append(engineOpts, ferret.WithNetwork(network))
+	}
+
 	engine, err := ferret.New(engineOpts...)
 
 	if err != nil {
+		if network != nil {
+			ferretnet.CloseIdleNetworkConnections(network)
+		}
+
 		_ = log.Close()
 		return nil, fmt.Errorf("initialize engine: %w", err)
 	}
 
 	return &Builtin{
-		opts:   opts,
-		engine: engine,
-		logger: log,
+		opts:    opts,
+		engine:  engine,
+		logger:  log,
+		network: network,
 	}, nil
 }
 
@@ -120,6 +150,10 @@ func (rt *Builtin) Close() error {
 
 	if rt.engine != nil {
 		err = errors.Join(err, rt.engine.Close())
+	}
+
+	if rt.network != nil {
+		ferretnet.CloseIdleNetworkConnections(rt.network)
 	}
 
 	if rt.logger != nil {

--- a/pkg/runtime/builtin_benchmark_test.go
+++ b/pkg/runtime/builtin_benchmark_test.go
@@ -1,0 +1,26 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/MontFerret/cli/v2/pkg/logger"
+)
+
+func BenchmarkBuiltinLifecycle(b *testing.B) {
+	opts := NewDefaultOptions()
+	opts.Logger.LogOutput = logger.OutputNone
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		rt, err := newBuiltin(opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if err := rt.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -152,13 +152,11 @@ func TestNewDebugSessionRejectsRemoteRuntime(t *testing.T) {
 		nil,
 		source.NewAnonymous("RETURN 1"),
 	)
+
 	if !errors.Is(err, ErrDebugRequiresBuiltinRuntime) {
 		t.Fatalf("expected builtin runtime error, got %v", err)
 	}
-	var typed *DebugRequiresBuiltinRuntimeError
-	if !errors.As(err, &typed) {
-		t.Fatalf("expected typed builtin runtime error, got %T", err)
-	}
+
 	if got := err.Error(); got != "debug currently supports only the builtin runtime" {
 		t.Fatalf("unexpected builtin runtime error: %q", got)
 	}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -2,20 +2,17 @@ package runtime
 
 import "errors"
 
-// ErrArtifactRequiresBuiltinRuntime indicates compiled artifacts can only run on the builtin runtime.
-var ErrArtifactRequiresBuiltinRuntime = errors.New("compiled artifacts require the builtin runtime")
+var (
+	// ErrArtifactRequiresBuiltinRuntime indicates compiled artifacts can only run on the builtin runtime.
+	ErrArtifactRequiresBuiltinRuntime = errors.New("compiled artifacts require the builtin runtime")
 
-// ErrHTTPPolicyRequiresBuiltinRuntime indicates HTTP policy options cannot configure a remote runtime.
-var ErrHTTPPolicyRequiresBuiltinRuntime = errors.New("HTTP policy options are only supported by the builtin runtime")
+	// ErrHTTPPolicyRequiresBuiltinRuntime indicates HTTP policy options cannot configure a remote runtime.
+	ErrHTTPPolicyRequiresBuiltinRuntime = errors.New("HTTP policy options are only supported by the builtin runtime")
 
-// DebugRequiresBuiltinRuntimeError reports an attempt to debug through a
-// runtime that cannot create local debugger sessions.
-type DebugRequiresBuiltinRuntimeError struct{}
+	// ErrFSPolicyRequiresBuiltinRuntime indicates filesystem policy options cannot configure a remote runtime.
+	ErrFSPolicyRequiresBuiltinRuntime = errors.New("filesystem policy options are only supported by the builtin runtime")
 
-func (*DebugRequiresBuiltinRuntimeError) Error() string {
-	return "debug currently supports only the builtin runtime"
-}
-
-// ErrDebugRequiresBuiltinRuntime indicates source debugging is only available
-// through the builtin runtime.
-var ErrDebugRequiresBuiltinRuntime = &DebugRequiresBuiltinRuntimeError{}
+	// ErrDebugRequiresBuiltinRuntime indicates source debugging is only available
+	// through the builtin runtime.
+	ErrDebugRequiresBuiltinRuntime = errors.New("debug currently supports only the builtin runtime")
+)

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -5,6 +5,9 @@ import "errors"
 // ErrArtifactRequiresBuiltinRuntime indicates compiled artifacts can only run on the builtin runtime.
 var ErrArtifactRequiresBuiltinRuntime = errors.New("compiled artifacts require the builtin runtime")
 
+// ErrHTTPPolicyRequiresBuiltinRuntime indicates HTTP policy options cannot configure a remote runtime.
+var ErrHTTPPolicyRequiresBuiltinRuntime = errors.New("HTTP policy options are only supported by the builtin runtime")
+
 // DebugRequiresBuiltinRuntimeError reports an attempt to debug through a
 // runtime that cannot create local debugger sessions.
 type DebugRequiresBuiltinRuntimeError struct{}

--- a/pkg/runtime/fs_policy_test.go
+++ b/pkg/runtime/fs_policy_test.go
@@ -1,0 +1,164 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func TestBuiltinFilesystemDefaultsToWritableCurrentDirectory(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	out, err := Run(
+		context.Background(),
+		NewDefaultOptions(),
+		source.NewAnonymous(`
+IO::FS::WRITE("output.txt", TO_BINARY("written"))
+RETURN true
+`),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	content, err := os.ReadFile(filepath.Join(root, "output.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "written" {
+		t.Fatalf("unexpected output content: %q", content)
+	}
+}
+
+func TestBuiltinFilesystemPolicyUsesConfiguredRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.txt"), []byte("fixture"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := NewDefaultOptions()
+	opts.FSPolicy = &FileSystemPolicy{Root: root}
+	out, err := Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(`RETURN TO_STRING(IO::FS::READ("fixture.txt"))`),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+}
+
+func TestBuiltinFilesystemPolicyRejectsRootEscape(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "outside.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := NewDefaultOptions()
+	opts.FSPolicy = &FileSystemPolicy{Root: root}
+	_, err := Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(`RETURN IO::FS::READ("../outside.txt")`),
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected root escape to fail")
+	}
+}
+
+func TestBuiltinFilesystemPolicyEnforcesReadOnly(t *testing.T) {
+	root := t.TempDir()
+	opts := NewDefaultOptions()
+	opts.FSPolicy = &FileSystemPolicy{Root: root, ReadOnly: true}
+
+	_, err := Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(`
+IO::FS::WRITE("output.txt", TO_BINARY("blocked"))
+RETURN true
+`),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "filesystem is read-only") {
+		t.Fatalf("expected read-only error, got %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(root, "output.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected output file not to exist, got %v", statErr)
+	}
+}
+
+func TestBuiltinFilesystemPolicyRejectsMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	opts := NewDefaultOptions()
+	opts.FSPolicy = &FileSystemPolicy{Root: root}
+
+	_, err := NewBuiltin(opts)
+	if err == nil || !strings.Contains(err.Error(), root) {
+		t.Fatalf("expected filesystem root error, got %v", err)
+	}
+}
+
+func TestNewRejectsFilesystemPolicyForRemoteRuntime(t *testing.T) {
+	opts := NewDefaultOptions()
+	opts.Type = "https://worker.example"
+	opts.FSPolicy = &FileSystemPolicy{ReadOnly: true}
+
+	_, err := New(opts)
+	if !errors.Is(err, ErrFSPolicyRequiresBuiltinRuntime) {
+		t.Fatalf("expected builtin runtime policy error, got %v", err)
+	}
+}
+
+func TestDebugSessionUsesConfiguredFilesystemPolicy(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.txt"), []byte("fixture"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := NewDefaultOptions()
+	opts.FSPolicy = &FileSystemPolicy{Root: root, ReadOnly: true}
+	session, err := NewDebugSession(
+		context.Background(),
+		opts,
+		nil,
+		source.NewAnonymous(`RETURN TO_STRING(IO::FS::READ("fixture.txt"))`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	event, err := session.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Reason != ferret.DebugReasonEntry {
+		t.Fatalf("expected debugger entry event, got %#v", event)
+	}
+
+	event, err = session.Continue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Reason != ferret.DebugReasonCompleted {
+		t.Fatalf("expected debugger completion event, got %#v", event)
+	}
+}

--- a/pkg/runtime/http_policy_test.go
+++ b/pkg/runtime/http_policy_test.go
@@ -1,0 +1,156 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func TestBuiltinHTTPPolicyBlocksLocalhostByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer server.Close()
+
+	_, err := Run(
+		context.Background(),
+		NewDefaultOptions(),
+		source.NewAnonymous(fmt.Sprintf("RETURN IO::NET::HTTP::GET(%q)", server.URL)),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "localhost is not allowed") {
+		t.Fatalf("expected localhost policy error, got %v", err)
+	}
+}
+
+func TestBuiltinHTTPPolicyAllowsConfiguredLocalhostAndSendsDefaultHeaders(t *testing.T) {
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Get("X-Ferret-Policy")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	opts := NewDefaultOptions()
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{
+		ferrethttp.WithAllowLocalhost(true),
+		ferrethttp.WithDefaultHeaders(map[string]string{"X-Ferret-Policy": "configured"}),
+	}
+
+	out, err := Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(fmt.Sprintf("RETURN TO_STRING(IO::NET::HTTP::GET(%q))", server.URL)),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	if got := <-requests; got != "configured" {
+		t.Fatalf("expected configured default header, got %q", got)
+	}
+}
+
+func TestBuiltinHTTPPolicyRejectsInvalidConfiguration(t *testing.T) {
+	opts := NewDefaultOptions()
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{ferrethttp.WithAllowedHosts("bad host")}
+
+	_, err := NewBuiltin(opts)
+	if err == nil || !strings.Contains(err.Error(), "WithAllowedHosts") {
+		t.Fatalf("expected allowed-host policy error, got %v", err)
+	}
+}
+
+func TestBuiltinHTTPPolicyEnforcesResponseLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("too large"))
+	}))
+	defer server.Close()
+
+	opts := NewDefaultOptions()
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{
+		ferrethttp.WithAllowLocalhost(true),
+		ferrethttp.WithMaxResponseSize(1),
+	}
+
+	_, err := Run(
+		context.Background(),
+		opts,
+		source.NewAnonymous(fmt.Sprintf("RETURN IO::NET::HTTP::GET(%q)", server.URL)),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "response body exceeds") {
+		t.Fatalf("expected response-size error, got %v", err)
+	}
+}
+
+func TestBuiltinCloseSucceedsWithConfiguredHTTPPolicy(t *testing.T) {
+	opts := NewDefaultOptions()
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{ferrethttp.WithAllowLocalhost(true)}
+
+	rt, err := NewBuiltin(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatalf("expected close to succeed, got %v", err)
+	}
+}
+
+func TestNewRejectsHTTPPolicyForRemoteRuntime(t *testing.T) {
+	opts := NewDefaultOptions()
+	opts.Type = "https://worker.example"
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{ferrethttp.WithAllowLocalhost(true)}
+
+	_, err := New(opts)
+	if !errors.Is(err, ErrHTTPPolicyRequiresBuiltinRuntime) {
+		t.Fatalf("expected builtin runtime policy error, got %v", err)
+	}
+}
+
+func TestDebugSessionUsesConfiguredHTTPPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	opts := NewDefaultOptions()
+	opts.HTTPPolicy = []ferrethttp.PolicyOption{ferrethttp.WithAllowLocalhost(true)}
+
+	session, err := NewDebugSession(
+		context.Background(),
+		opts,
+		nil,
+		source.NewAnonymous(fmt.Sprintf("RETURN TO_STRING(IO::NET::HTTP::GET(%q))", server.URL)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	event, err := session.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Reason != ferret.DebugReasonEntry {
+		t.Fatalf("expected debugger entry event, got %#v", event)
+	}
+
+	event, err = session.Continue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Reason != ferret.DebugReasonCompleted {
+		t.Fatalf("expected debugger completion event, got %#v", event)
+	}
+}

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -20,10 +20,17 @@ type Options struct {
 	BrowserAddress      string
 	WithBrowser         bool
 	WithHeadlessBrowser bool
-	FileSystemRoot      string
 	Logger              logger.Options
+	// FSPolicy configures filesystem access for the builtin runtime only.
+	FSPolicy *FileSystemPolicy
 	// HTTPPolicy configures outbound HTTP for the builtin runtime only.
 	HTTPPolicy []ferrethttp.PolicyOption
+}
+
+// FileSystemPolicy configures the sandboxed filesystem used by the builtin runtime.
+type FileSystemPolicy struct {
+	Root     string
+	ReadOnly bool
 }
 
 func NewDefaultOptions() Options {
@@ -48,16 +55,18 @@ func ValidateOptions(opts Options) error {
 		return err
 	}
 
-	if len(opts.HTTPPolicy) == 0 {
-		return nil
+	if len(opts.HTTPPolicy) > 0 {
+		if !IsBuiltinType(opts.Type) {
+			return ErrHTTPPolicyRequiresBuiltinRuntime
+		}
+
+		if _, err := ferrethttp.NewPolicy(opts.HTTPPolicy...); err != nil {
+			return fmt.Errorf("HTTP policy: %w", err)
+		}
 	}
 
-	if !IsBuiltinType(opts.Type) {
-		return ErrHTTPPolicyRequiresBuiltinRuntime
-	}
-
-	if _, err := ferrethttp.NewPolicy(opts.HTTPPolicy...); err != nil {
-		return fmt.Errorf("HTTP policy: %w", err)
+	if opts.FSPolicy != nil && !IsBuiltinType(opts.Type) {
+		return ErrFSPolicyRequiresBuiltinRuntime
 	}
 
 	return nil

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -1,10 +1,13 @@
 package runtime
 
 import (
+	"fmt"
+
 	"github.com/MontFerret/cli/v2/pkg/logger"
 	"github.com/MontFerret/contrib/modules/web/html/drivers"
 	"github.com/MontFerret/contrib/modules/web/html/drivers/cdp"
 	"github.com/MontFerret/contrib/modules/web/html/drivers/memory"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 )
 
 type Options struct {
@@ -19,6 +22,8 @@ type Options struct {
 	WithHeadlessBrowser bool
 	FileSystemRoot      string
 	Logger              logger.Options
+	// HTTPPolicy configures outbound HTTP for the builtin runtime only.
+	HTTPPolicy []ferrethttp.PolicyOption
 }
 
 func NewDefaultOptions() Options {
@@ -39,7 +44,23 @@ func NewDefaultOptions() Options {
 func ValidateOptions(opts Options) error {
 	opts = NormalizeOptions(opts)
 
-	return opts.Logger.Validate()
+	if err := opts.Logger.Validate(); err != nil {
+		return err
+	}
+
+	if len(opts.HTTPPolicy) == 0 {
+		return nil
+	}
+
+	if !IsBuiltinType(opts.Type) {
+		return ErrHTTPPolicyRequiresBuiltinRuntime
+	}
+
+	if _, err := ferrethttp.NewPolicy(opts.HTTPPolicy...); err != nil {
+		return fmt.Errorf("HTTP policy: %w", err)
+	}
+
+	return nil
 }
 
 func NormalizeOptions(opts Options) Options {


### PR DESCRIPTION
This pull request introduces comprehensive filesystem and HTTP security policy controls for the Ferret CLI's builtin runtime. It adds new command-line flags, environment variables, and configuration options to restrict filesystem access and outbound HTTP requests, improving script isolation and security. The changes include updates to documentation, new implementation code, and thorough tests.

The most important changes are:

**Filesystem policy support:**
* Added new `--policy-fs-root` and `--policy-fs-read-only` flags (and corresponding environment/config options) to restrict the builtin runtime's filesystem access to a sandboxed directory, optionally read-only. Implemented in `cmd/fs_policy.go`, with tests in `cmd/fs_policy_test.go`. [[1]](diffhunk://#diff-856632a7dc00816282c2a416c1d37e0c8aa0c5bad39c88a8ca04ee5084b26a32R1-R56) [[2]](diffhunk://#diff-ca04cbc9276fbdad7891ec94d674743c65cb966fd1aea4415ab6cbe86f1be231R1-R228)
* Removed the legacy `--runtime-fs-root` flag and ensured it is not accepted or displayed in help output. [[1]](diffhunk://#diff-e231d920accff9e68d1581fc082513cda53631f2a312c9005448288b29dd08a3L12-R19) [[2]](diffhunk://#diff-ca04cbc9276fbdad7891ec94d674743c65cb966fd1aea4415ab6cbe86f1be231R1-R228)

**HTTP policy support:**
* Introduced a suite of HTTP policy flags (e.g., `--policy-http-allowed-hosts`, `--policy-http-allow-localhost`, `--policy-http-default-headers`, and more) to control outbound HTTP access, methods, hosts, headers, timeouts, and size limits. Implemented in `cmd/http_policy.go`.

**Integration and validation:**
* Updated command construction and runtime option parsing to wire filesystem and HTTP policy options into the builtin runtime, and to reject policy flags when using a remote runtime. [[1]](diffhunk://#diff-c708ab24ce1605f61b63c092be17b60e42343b541b1da6540010c0fca27e6686L42-R47) [[2]](diffhunk://#diff-856632a7dc00816282c2a416c1d37e0c8aa0c5bad39c88a8ca04ee5084b26a32R1-R56) [[3]](diffhunk://#diff-ac5ed5bb34fd335f8e5d17bc314c0394d31637c11a91cc6865f0f464fba44e55R1-R234) [[4]](diffhunk://#diff-ca04cbc9276fbdad7891ec94d674743c65cb966fd1aea4415ab6cbe86f1be231R1-R228)

**Documentation and configuration:**
* Extended `README.md` with detailed sections on filesystem and HTTP policy usage, including flag/environment/config tables and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R215) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237-R239)

These changes significantly improve the security model for scripts executed with the Ferret CLI by allowing fine-grained control over what files and network resources scripts can access.