### PR TITLE
Feat/policy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,16 @@ ferret config set browser-address http://127.0.0.1:9222
 ferret config set policy-fs-root ./fixtures
 ferret config set policy-fs-read-only true
 ferret config set policy-http-allow-localhost true
+ferret config set policy-http-allowed-hosts api.example.com,cdn.example.com
+ferret config set policy-http-default-headers '{"X-Trace":"local"}'
 ferret config get browser-address
 ferret config list
+ferret config unset policy-http-allowed-hosts
 ```
+
+`config set` validates the complete persisted filesystem and HTTP policy before writing it. Invalid policy values and conflicting controls, such as setting both `policy-http-timeout` and `policy-http-no-timeout=true`, leave the existing config unchanged. List values use comma-separated strings, and default headers use a JSON object with string values.
+
+`config unset` removes only the value stored in the config file and restores the implicit default for that key. Command-line flags and environment variables remain unaffected.
 
 ## Development
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -33,11 +33,11 @@ func ConfigCommand(store *config.Store) *cobra.Command {
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			store.BindFlags(cmd)
 		},
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			val, err := store.Get(args[0])
 
 			if err == nil {
-				fmt.Println(val)
+				fmt.Fprintln(cmd.OutOrStdout(), val)
 
 				return nil
 			}
@@ -53,12 +53,34 @@ func ConfigCommand(store *config.Store) *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "set",
 		Short: "Set a Ferret config value by key",
-		Args:  cobra.MinimumNArgs(2),
+		Args:  cobra.ExactArgs(2),
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			store.BindFlags(cmd)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			if err := validatePolicyConfigSet(store, args[0], args[1]); err != nil {
+				return err
+			}
+
 			err := store.Set(args[0], args[1])
+
+			if err == config.ErrInvalidFlag {
+				return fmt.Errorf("%s\n%s", err, config.FlagsStr)
+			}
+
+			return err
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "unset",
+		Short: "Remove a persisted Ferret config value by key",
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			store.BindFlags(cmd)
+		},
+		RunE: func(_ *cobra.Command, args []string) error {
+			err := store.Unset(args[0])
 
 			if err == config.ErrInvalidFlag {
 				return fmt.Errorf("%s\n%s", err, config.FlagsStr)
@@ -76,9 +98,9 @@ func ConfigCommand(store *config.Store) *cobra.Command {
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			store.BindFlags(cmd)
 		},
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			for _, kv := range store.List() {
-				fmt.Printf("%s: %v\n", kv.Key, kv.Value)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s: %v\n", kv.Key, kv.Value)
 			}
 		},
 	})

--- a/cmd/config_policy.go
+++ b/cmd/config_policy.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+)
+
+var policyConfigKeys = []string{
+	config.PolicyFSRoot,
+	config.PolicyFSReadOnly,
+	config.PolicyHTTPAllowedSchemes,
+	config.PolicyHTTPAllowedMethods,
+	config.PolicyHTTPAllowedHosts,
+	config.PolicyHTTPBlockedHosts,
+	config.PolicyHTTPAllowLocalhost,
+	config.PolicyHTTPAllowPrivateNetworks,
+	config.PolicyHTTPAllowLinkLocal,
+	config.PolicyHTTPDefaultHeaders,
+	config.PolicyHTTPBlockedRequestHeaders,
+	config.PolicyHTTPTimeout,
+	config.PolicyHTTPNoTimeout,
+	config.PolicyHTTPMaxRequestSize,
+	config.PolicyHTTPUnlimitedRequestSize,
+	config.PolicyHTTPMaxResponseSize,
+	config.PolicyHTTPUnlimitedResponseSize,
+	config.PolicyHTTPMaxResponseHeaderSize,
+	config.PolicyHTTPFollowRedirects,
+	config.PolicyHTTPMaxRedirects,
+}
+
+func validatePolicyConfigSet(store *config.Store, key, value string) error {
+	if !isPolicyConfigKey(key) {
+		return nil
+	}
+
+	command := &cobra.Command{Use: "config-policy-validation"}
+	addFSPolicyFlags(command)
+	addHTTPPolicyFlags(command)
+
+	for _, policyKey := range policyConfigKeys {
+		policyValue, err := persistedPolicyValue(store, policyKey, key, value)
+		if err != nil {
+			return err
+		}
+		if policyValue == nil {
+			continue
+		}
+
+		if err := command.Flags().Set(policyKey, fmt.Sprint(policyValue)); err != nil {
+			return fmt.Errorf("invalid policy configuration for %q: %w", policyKey, err)
+		}
+	}
+
+	fsPolicy, err := fsPolicyFromCommand(command)
+	if err != nil {
+		return fmt.Errorf("invalid policy configuration for %q: %w", key, err)
+	}
+
+	httpPolicy, err := httpPolicyOptionsFromCommand(command)
+	if err != nil {
+		return fmt.Errorf("invalid policy configuration for %q: %w", key, err)
+	}
+
+	opts := cliruntime.NewDefaultOptions()
+	opts.FSPolicy = fsPolicy
+	opts.HTTPPolicy = httpPolicy
+
+	if err := cliruntime.ValidateOptions(opts); err != nil {
+		return fmt.Errorf("invalid policy configuration for %q: %w", key, err)
+	}
+
+	return nil
+}
+
+func persistedPolicyValue(store *config.Store, policyKey, candidateKey, candidateValue string) (any, error) {
+	if policyKey == candidateKey {
+		return candidateValue, nil
+	}
+
+	return store.Get(policyKey)
+}
+
+func isPolicyConfigKey(key string) bool {
+	for _, policyKey := range policyConfigKeys {
+		if policyKey == key {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,352 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/MontFerret/cli/v2/pkg/config"
+	cliruntime "github.com/MontFerret/cli/v2/pkg/runtime"
+)
+
+func TestConfigCommandPolicyRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	store := newConfigCommandTestStore(t, home)
+	values := []struct {
+		key   string
+		value string
+	}{
+		{config.PolicyFSRoot, "./fixtures"},
+		{config.PolicyFSReadOnly, "true"},
+		{config.PolicyHTTPAllowedSchemes, "http,https"},
+		{config.PolicyHTTPAllowedMethods, "GET,POST"},
+		{config.PolicyHTTPAllowedHosts, "api.example.com,cdn.example.com"},
+		{config.PolicyHTTPBlockedHosts, "blocked.example.com"},
+		{config.PolicyHTTPAllowLocalhost, "true"},
+		{config.PolicyHTTPAllowPrivateNetworks, "true"},
+		{config.PolicyHTTPAllowLinkLocal, "true"},
+		{config.PolicyHTTPDefaultHeaders, `{"X-Trace":"config"}`},
+		{config.PolicyHTTPBlockedRequestHeaders, "Authorization,X-Secret"},
+		{config.PolicyHTTPTimeout, "5s"},
+		{config.PolicyHTTPNoTimeout, "false"},
+		{config.PolicyHTTPMaxRequestSize, "1024"},
+		{config.PolicyHTTPUnlimitedRequestSize, "false"},
+		{config.PolicyHTTPMaxResponseSize, "2048"},
+		{config.PolicyHTTPUnlimitedResponseSize, "false"},
+		{config.PolicyHTTPMaxResponseHeaderSize, "4096"},
+		{config.PolicyHTTPFollowRedirects, "false"},
+		{config.PolicyHTTPMaxRedirects, "3"},
+	}
+
+	for _, value := range values {
+		if _, err := executeConfigCommand(store, "set", value.key, value.value); err != nil {
+			t.Fatalf("set %s: %v", value.key, err)
+		}
+	}
+
+	homedir.Reset()
+	store = newConfigCommandTestStore(t, home)
+
+	for _, value := range values {
+		out, err := executeConfigCommand(store, "get", value.key)
+		if err != nil {
+			t.Fatalf("get %s: %v", value.key, err)
+		}
+		if got := strings.TrimSpace(out); got != value.value {
+			t.Fatalf("get %s: expected %q, got %q", value.key, value.value, got)
+		}
+	}
+
+	list, err := executeConfigCommand(store, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range values {
+		if !strings.Contains(list, fmt.Sprintf("%s: %s", value.key, value.value)) {
+			t.Fatalf("config list does not contain %s: %s\n%s", value.key, value.value, list)
+		}
+	}
+
+	runCommand := RunCommand(store)
+	store.BindFlags(runCommand)
+	opts, err := runtimeOptionsFromCommand(runCommand, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.FSPolicy == nil || opts.FSPolicy.Root != "./fixtures" || !opts.FSPolicy.ReadOnly {
+		t.Fatalf("unexpected filesystem policy: %#v", opts.FSPolicy)
+	}
+	if len(opts.HTTPPolicy) == 0 {
+		t.Fatal("expected persisted HTTP policy options")
+	}
+	if err := cliruntime.ValidateOptions(opts); err != nil {
+		t.Fatalf("expected persisted policy to validate, got %v", err)
+	}
+}
+
+func TestPolicyConfigKeysCoverSupportedPolicyFlags(t *testing.T) {
+	for _, key := range config.Flags {
+		if strings.HasPrefix(key, "policy-") && !isPolicyConfigKey(key) {
+			t.Fatalf("supported policy key %q is missing config validation", key)
+		}
+	}
+}
+
+func TestConfigCommandRejectsInvalidPolicyValuesWithoutWriting(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "blank filesystem root", key: config.PolicyFSRoot, value: " \t "},
+		{name: "filesystem boolean", key: config.PolicyFSReadOnly, value: "sometimes"},
+		{name: "scheme", key: config.PolicyHTTPAllowedSchemes, value: "not a scheme"},
+		{name: "method", key: config.PolicyHTTPAllowedMethods, value: "bad method"},
+		{name: "allowed host", key: config.PolicyHTTPAllowedHosts, value: "bad host"},
+		{name: "blocked host", key: config.PolicyHTTPBlockedHosts, value: "bad host"},
+		{name: "boolean", key: config.PolicyHTTPAllowLocalhost, value: "sometimes"},
+		{name: "headers JSON", key: config.PolicyHTTPDefaultHeaders, value: `{"X-Trace":1}`},
+		{name: "blocked header", key: config.PolicyHTTPBlockedRequestHeaders, value: "bad header"},
+		{name: "duration", key: config.PolicyHTTPTimeout, value: "later"},
+		{name: "request size", key: config.PolicyHTTPMaxRequestSize, value: "-1"},
+		{name: "response size", key: config.PolicyHTTPMaxResponseSize, value: "-1"},
+		{name: "response header size", key: config.PolicyHTTPMaxResponseHeaderSize, value: "-1"},
+		{name: "redirect count", key: config.PolicyHTTPMaxRedirects, value: "-1"},
+		{name: "list CSV", key: config.PolicyHTTPAllowedHosts, value: `"unterminated`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			store := newConfigCommandTestStore(t, home)
+			if err := store.Set(config.ExecRuntime, "builtin"); err != nil {
+				t.Fatal(err)
+			}
+			before := readConfigCommandTestFile(t, home)
+
+			args := []string{"set", tt.key, tt.value}
+			if strings.HasPrefix(tt.value, "-") {
+				args = []string{"set", tt.key, "--", tt.value}
+			}
+
+			_, err := executeConfigCommand(store, args...)
+			if err == nil || !strings.Contains(err.Error(), "invalid policy configuration") {
+				t.Fatalf("expected policy validation error, got %v", err)
+			}
+
+			got, getErr := store.Get(tt.key)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			if got != nil {
+				t.Fatalf("expected rejected value not to be stored, got %v", got)
+			}
+
+			runtimeValue, getErr := store.Get(config.ExecRuntime)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			if runtimeValue != "builtin" {
+				t.Fatalf("expected existing config to remain unchanged, got %v", runtimeValue)
+			}
+
+			after := readConfigCommandTestFile(t, home)
+			if !bytes.Equal(before, after) {
+				t.Fatalf("expected rejected value not to change config file\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+		})
+	}
+}
+
+func TestConfigCommandRejectsPolicyConflictsWithoutWriting(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingKey    string
+		existingValue  string
+		candidateKey   string
+		candidateValue string
+	}{
+		{
+			name:           "timeout and no timeout",
+			existingKey:    config.PolicyHTTPTimeout,
+			existingValue:  "1s",
+			candidateKey:   config.PolicyHTTPNoTimeout,
+			candidateValue: "true",
+		},
+		{
+			name:           "no timeout and timeout",
+			existingKey:    config.PolicyHTTPNoTimeout,
+			existingValue:  "true",
+			candidateKey:   config.PolicyHTTPTimeout,
+			candidateValue: "1s",
+		},
+		{
+			name:           "request limit and unlimited request",
+			existingKey:    config.PolicyHTTPMaxRequestSize,
+			existingValue:  "1",
+			candidateKey:   config.PolicyHTTPUnlimitedRequestSize,
+			candidateValue: "true",
+		},
+		{
+			name:           "unlimited request and request limit",
+			existingKey:    config.PolicyHTTPUnlimitedRequestSize,
+			existingValue:  "true",
+			candidateKey:   config.PolicyHTTPMaxRequestSize,
+			candidateValue: "1",
+		},
+		{
+			name:           "response limit and unlimited response",
+			existingKey:    config.PolicyHTTPMaxResponseSize,
+			existingValue:  "1",
+			candidateKey:   config.PolicyHTTPUnlimitedResponseSize,
+			candidateValue: "true",
+		},
+		{
+			name:           "unlimited response and response limit",
+			existingKey:    config.PolicyHTTPUnlimitedResponseSize,
+			existingValue:  "true",
+			candidateKey:   config.PolicyHTTPMaxResponseSize,
+			candidateValue: "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			store := newConfigCommandTestStore(t, home)
+			if err := store.Set(tt.existingKey, tt.existingValue); err != nil {
+				t.Fatal(err)
+			}
+			before := readConfigCommandTestFile(t, home)
+
+			_, err := executeConfigCommand(store, "set", tt.candidateKey, tt.candidateValue)
+			if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+				t.Fatalf("expected conflict error, got %v", err)
+			}
+
+			got, getErr := store.Get(tt.candidateKey)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			if got != nil {
+				t.Fatalf("expected conflicting value not to be stored, got %v", got)
+			}
+
+			existing, getErr := store.Get(tt.existingKey)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			if existing != tt.existingValue {
+				t.Fatalf("expected existing value %q, got %v", tt.existingValue, existing)
+			}
+
+			after := readConfigCommandTestFile(t, home)
+			if !bytes.Equal(before, after) {
+				t.Fatalf("expected conflict not to change config file\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+		})
+	}
+}
+
+func TestConfigCommandUnsetRestoresImplicitPolicyDefaults(t *testing.T) {
+	home := t.TempDir()
+	store := newConfigCommandTestStore(t, home)
+
+	if _, err := executeConfigCommand(store, "set", config.PolicyFSRoot, "./fixtures"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executeConfigCommand(store, "set", config.PolicyHTTPAllowLocalhost, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executeConfigCommand(store, "unset", config.PolicyFSRoot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executeConfigCommand(store, "unset", config.PolicyHTTPAllowLocalhost); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executeConfigCommand(store, "unset", config.PolicyHTTPAllowLocalhost); err != nil {
+		t.Fatalf("expected repeated unset to succeed, got %v", err)
+	}
+
+	homedir.Reset()
+	store = newConfigCommandTestStore(t, home)
+	runCommand := RunCommand(store)
+	store.BindFlags(runCommand)
+	opts, err := runtimeOptionsFromCommand(runCommand, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.FSPolicy != nil {
+		t.Fatalf("expected implicit filesystem defaults, got %#v", opts.FSPolicy)
+	}
+	if len(opts.HTTPPolicy) != 0 {
+		t.Fatalf("expected implicit HTTP defaults, got %d options", len(opts.HTTPPolicy))
+	}
+}
+
+func TestConfigCommandUnsetRejectsUnsupportedKey(t *testing.T) {
+	store := newConfigCommandTestStore(t, t.TempDir())
+
+	_, err := executeConfigCommand(store, "unset", "not-a-config-key")
+	if err == nil || !strings.Contains(err.Error(), config.ErrInvalidFlag.Error()) {
+		t.Fatalf("expected invalid flag error, got %v", err)
+	}
+}
+
+func TestConfigCommandSetAndUnsetRequireExactArguments(t *testing.T) {
+	store := newConfigCommandTestStore(t, t.TempDir())
+
+	for _, args := range [][]string{
+		{"set", config.PolicyFSRoot},
+		{"set", config.PolicyFSRoot, ".", "extra"},
+		{"unset"},
+		{"unset", config.PolicyFSRoot, "extra"},
+	} {
+		if _, err := executeConfigCommand(store, args...); err == nil {
+			t.Fatalf("expected argument error for %v", args)
+		}
+	}
+}
+
+func executeConfigCommand(store *config.Store, args ...string) (string, error) {
+	command := ConfigCommand(store)
+	out := new(bytes.Buffer)
+	command.SetOut(out)
+	command.SetErr(out)
+	command.SetArgs(args)
+
+	err := command.Execute()
+
+	return out.String(), err
+}
+
+func readConfigCommandTestFile(t *testing.T, home string) []byte {
+	t.Helper()
+
+	contents, err := os.ReadFile(filepath.Join(home, ".ferret", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return contents
+}
+
+func newConfigCommandTestStore(t *testing.T, home string) *config.Store {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := config.NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return store
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/MontFerret/contrib/modules/web/sitemap v1.0.0-rc.9
 	github.com/MontFerret/contrib/modules/xml v1.0.0-rc.9
 	github.com/MontFerret/contrib/modules/yaml v1.0.0-rc.9
-	github.com/MontFerret/ferret/v2 v2.0.0-alpha.34
+	github.com/MontFerret/ferret/v2 v2.0.0-alpha.37
 	github.com/chzyer/readline v1.5.1
 	github.com/go-waitfor/waitfor v1.1.0
 	github.com/go-waitfor/waitfor-http v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/MontFerret/contrib/pkg/common v0.1.1 h1:qA2URATIO+EVLH3BNFKYupLx97fto
 github.com/MontFerret/contrib/pkg/common v0.1.1/go.mod h1:wiMLQnE46YGci3qMzA3ExArKomQDXR5DvNSE7HnP0ik=
 github.com/MontFerret/cssx v0.2.0 h1:De0C6Irbg+qgFPXgWmPpVnwD4RRYUBQSbIYFTUVCNWU=
 github.com/MontFerret/cssx v0.2.0/go.mod h1:fmGtRUNVaeJYpiPSDlNIbbYzb3+K8NxmNmJOYqlHATU=
-github.com/MontFerret/ferret/v2 v2.0.0-alpha.34 h1:Yfjwq2h5IWsnvrK5T4iJ9k0FFVgheOCJBg8V/cp6Ix4=
-github.com/MontFerret/ferret/v2 v2.0.0-alpha.34/go.mod h1:jkZZNJrQKhQ8K9v3lzkMKR5NnCyOUKRRKCTAwCOBq8A=
+github.com/MontFerret/ferret/v2 v2.0.0-alpha.37 h1:3c7+KmXPsuCoi2/Wy7YCvvSaEeCCKdwO+5AsET34cZE=
+github.com/MontFerret/ferret/v2 v2.0.0-alpha.37/go.mod h1:jkZZNJrQKhQ8K9v3lzkMKR5NnCyOUKRRKCTAwCOBq8A=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/andybalholm/cascadia v1.3.4 h1:vM2lgh0Vru9Vwyfm4cQqWP2HHMW0u0+2PAW7Q38Qufg=

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -175,6 +175,50 @@ func (s *Store) Set(key, val string) error {
 	return s.v.WriteConfig()
 }
 
+// Unset removes a persisted configuration value without affecting flags or
+// environment variables. Calling Unset for a supported key that is not present
+// in the config file is a no-op.
+func (s *Store) Unset(key string) error {
+	if !isSupportedFlag(key) {
+		return ErrInvalidFlag
+	}
+
+	configFile := s.v.ConfigFileUsed()
+	persisted := viper.New()
+	persisted.SetConfigFile(configFile)
+
+	if err := persisted.ReadInConfig(); err != nil {
+		return err
+	}
+
+	if !persisted.IsSet(key) {
+		s.v.Set(key, nil)
+
+		return s.v.ReadInConfig()
+	}
+
+	settings := persisted.AllSettings()
+	delete(settings, key)
+
+	next := viper.New()
+	next.SetConfigFile(configFile)
+	next.SetConfigType("yaml")
+
+	if err := next.MergeConfigMap(settings); err != nil {
+		return err
+	}
+
+	if err := next.WriteConfig(); err != nil {
+		return err
+	}
+
+	// Clear a value previously installed through Set, then reload only the
+	// file-backed layer so existing flag and environment bindings remain intact.
+	s.v.Set(key, nil)
+
+	return s.v.ReadInConfig()
+}
+
 func (s *Store) List() []KV {
 	list := make([]KV, 0, len(Flags))
 

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+)
+
+func TestStoreUnsetRemovesOnlyPersistedValue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Set(ExecRuntime, "builtin"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(PolicyFSRoot, "./fixtures"); err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := filepath.Join(home, ".ferret", "config.yaml")
+	contents, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents = append(contents, []byte("custom-setting: keep\n")...)
+	if err := os.WriteFile(configFile, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	homedir.Reset()
+	store, err = NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Unset(PolicyFSRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(PolicyFSRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected filesystem root to be removed, got %v", got)
+	}
+
+	got, err = store.Get(ExecRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "builtin" {
+		t.Fatalf("expected runtime to remain persisted, got %v", got)
+	}
+
+	contents, err = os.ReadFile(configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "custom-setting: keep") {
+		t.Fatalf("expected unknown config entry to be preserved:\n%s", contents)
+	}
+	if strings.Contains(string(contents), PolicyFSRoot+":") {
+		t.Fatalf("expected filesystem root to be removed:\n%s", contents)
+	}
+
+	if err := store.Unset(PolicyFSRoot); err != nil {
+		t.Fatalf("expected repeated unset to be idempotent, got %v", err)
+	}
+}
+
+func TestStoreUnsetDoesNotAffectEnvironment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("FERRET_RUNTIME", "https://runtime.example")
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(ExecRuntime, "builtin"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Unset(ExecRuntime); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ExecRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://runtime.example" {
+		t.Fatalf("expected environment runtime after unset, got %v", got)
+	}
+}
+
+func TestStoreUnsetDoesNotAffectBoundFlags(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(ExecRuntime, "builtin"); err != nil {
+		t.Fatal(err)
+	}
+
+	command := &cobra.Command{Use: "config-test"}
+	command.Flags().String(ExecRuntime, "", "")
+	if err := command.Flags().Set(ExecRuntime, "https://runtime.example"); err != nil {
+		t.Fatal(err)
+	}
+	store.BindFlags(command)
+
+	if err := store.Unset(ExecRuntime); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(ExecRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://runtime.example" {
+		t.Fatalf("expected bound flag runtime after unset, got %v", got)
+	}
+}
+
+func TestStoreUnsetRejectsUnsupportedKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+
+	store, err := NewStore("ferret", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Unset("not-a-config-key"); !errors.Is(err, ErrInvalidFlag) {
+		t.Fatalf("expected invalid flag error, got %v", err)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `config unset` command for removing persisted configuration values, enforces strict validation and argument requirements for `config set` and `unset`, and improves policy configuration validation to prevent invalid or conflicting settings. The changes also update documentation and add comprehensive tests for these features.

### New Features

* Added a `config unset` command to remove a persisted configuration value by key, restoring the implicit default without affecting flags or environment variables. (`cmd/config.go` [[1]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaR75-R92) `pkg/config/store.go` [[2]](diffhunk://#diff-7e087f6a82b69c51db9d11ed6fb804fafe727b9dded6c686ecbb31c71a4d8f24R178-R221) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R240-R250)
* Introduced the `Store.Unset` method to handle removal of persisted config values, ensuring only the config file is affected. (`pkg/config/store.go` [pkg/config/store.goR178-R221](diffhunk://#diff-7e087f6a82b69c51db9d11ed6fb804fafe727b9dded6c686ecbb31c71a4d8f24R178-R221))

### Policy Validation Improvements

* Implemented strict validation for policy-related config keys in `config set`, rejecting invalid or conflicting values and leaving the existing config unchanged if validation fails. (`cmd/config_policy.go` [[1]](diffhunk://#diff-962fcb8c286df17e6dcdc4493e13fd4c3950baa5af96e0ec7c17206a8758c444R1-R95) `cmd/config.go` [[2]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL56-R64) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R240-R250)

### Command-Line Interface Enhancements

* Updated argument requirements: `config set` and `config unset` now require exact arguments, improving usability and preventing accidental misconfiguration. (`cmd/config.go` [[1]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL56-R64) [[2]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaR75-R92) `cmd/config_test.go` [[3]](diffhunk://#diff-61b7e86a6c9f19d7beb19e22addacc2beba35191f72f25fc75f5cb8534a54abaR1-R352)
* Output for `config get` and `config list` is now written to the command's output stream, improving integration with other tools. (`cmd/config.go` [[1]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL36-R40) [[2]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL79-R103)

### Testing and Documentation

* Added comprehensive tests for `config unset`, policy validation, argument checking, and conflict handling to ensure robust behavior. (`cmd/config_test.go` [[1]](diffhunk://#diff-61b7e86a6c9f19d7beb19e22addacc2beba35191f72f25fc75f5cb8534a54abaR1-R352) `pkg/config/store_test.go` [[2]](diffhunk://#diff-2fe3467e4aa2aa36cfcbd96223fbcf175487d269458d772f1a46565cdec9cccdR1-R158)
* Improved documentation in `README.md` to describe new commands and validation behavior. (`README.md` [README.mdR240-R250](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R240-R250))

### Dependency Updates

* Updated `github.com/MontFerret/ferret/v2` dependency to version `v2.0.0-alpha.37`. (`go.mod` [go.modL21-R21](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L21-R21))