### PR TITLE
Add GitHub module to submit registry publications via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ ferret browser open         # Start a managed browser
 ferret config list          # Show configuration
 ferret mod search sqlite    # Search the Ferret module registry
 ferret mod install montferret/archive # Install a module into a Go application
+ferret mod publish          # Submit a tagged module release to the Registry
 ferret version              # Show version information
 ```
 
@@ -167,22 +168,53 @@ ferret mod init acme/sqlite \
   --namespace DB::SQLITE
 ```
 
-The scaffold contains schema-valid TODO metadata. Replace it before preparing
-a release, commit the module files, and push the release tag. The manifest must
-identify a public repository that supports anonymous HTTPS Git access. From the
-module root, print the validated Barn registration records and pull-request
-guidance:
+The scaffold contains schema-valid TODO metadata. Replace it before publishing
+a release. The manifest must identify a public repository that supports
+anonymous HTTPS Git access. Commit the module files, create and push the release
+tag, then run the publication command from the module root:
 
 ```bash
+git tag v1.0.0
+git push origin v1.0.0
 ferret mod publish
 ```
 
 By default, the tag is `v<version>` for a standalone module or
 `<repository.directory>/v<version>` for a monorepo module. For non-standard
-release tags, pass `--tag`. Publication preparation consults the public
-registry, inspects the pushed tag through anonymous HTTPS Git, and returns only
-the records needed for a new module or version. It does not write records,
-upload packages, authenticate with a provider, or open a pull request.
+release tags, pass `--tag`.
+
+Publication validates `ferret.yaml`, resolves the public tag and pinned commit,
+checks the adjacent `README.md` and `go.mod`, consults the current Registry, and
+prepares only the immutable Barn source records needed for the release. The CLI
+then uses the GitHub API to create or reuse your personal Barn fork, create a
+focused publication branch, and open a pull request against
+`MontFerret/barn`. You do not need a local Barn checkout or knowledge of its
+record layout.
+
+Set `GH_TOKEN` or `GITHUB_TOKEN` before publishing. If neither is set, Ferret
+uses the token from `gh auth token --hostname github.com`; authenticate it with
+`gh auth login --hostname github.com` when needed. The credential must be able
+to write to your personal Barn fork and open a pull request against the public
+Barn repository.
+
+Validate the complete release without authenticating or mutating GitHub:
+
+```bash
+ferret mod publish --dry-run
+```
+
+Print the deterministic Barn-relative records as a versioned JSON document for
+inspection or unusual manual automation:
+
+```bash
+ferret mod publish --print
+```
+
+`--dry-run` and `--print` cannot be combined, and neither mode submits records.
+Publication retries are safe: an already-published version exits successfully,
+and an exact open pull request or publication branch is reused. Ferret never
+overwrites an immutable Registry record or a divergent branch; delete a stale
+publication branch from your fork before retrying if its contents differ.
 
 ## Browser usage
 

--- a/cmd/facade_module_service_test.go
+++ b/cmd/facade_module_service_test.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"context"
 
-	barnpublish "github.com/MontFerret/barn/pkg/publish"
-
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
@@ -29,6 +27,6 @@ func (f *facadeModuleService) Create(context.Context, scaffold.Options) (*scaffo
 	return nil, nil
 }
 
-func (f *facadeModuleService) Publish(context.Context, modulepublish.Options) (*barnpublish.Result, error) {
+func (f *facadeModuleService) Publish(context.Context, modulepublish.Options) (*modulepublish.Result, error) {
 	return nil, nil
 }

--- a/cmd/internal/mod/command.go
+++ b/cmd/internal/mod/command.go
@@ -15,6 +15,8 @@ const (
 	moduleDirFlag       = "dir"
 	moduleNamespaceFlag = "namespace"
 	moduleTagFlag       = "tag"
+	moduleDryRunFlag    = "dry-run"
+	modulePrintFlag     = "print"
 	moduleYesFlag       = "yes"
 )
 
@@ -185,7 +187,7 @@ func moduleInitCommand(service Service, terminal terminalDetector, prompts promp
 func modulePublishCommand(service Service) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "publish",
-		Short: "Prepare Barn registration records for the current module release",
+		Short: "Publish the current module release to the Ferret Registry",
 		Args:  cobra.MaximumNArgs(0),
 		RunE: func(command *cobra.Command, _ []string) error {
 			tag, err := command.Flags().GetString(moduleTagFlag)
@@ -193,18 +195,49 @@ func modulePublishCommand(service Service) *cobra.Command {
 				return err
 			}
 
-			publication, err := service.Publish(command.Context(), modulepublish.Options{Directory: ".", Tag: tag})
+			dryRun, err := command.Flags().GetBool(moduleDryRunFlag)
 			if err != nil {
 				return err
 			}
 
-			renderModulePublication(command.OutOrStdout(), publication)
+			printRecords, err := command.Flags().GetBool(modulePrintFlag)
+			if err != nil {
+				return err
+			}
 
-			return nil
+			if dryRun && printRecords {
+				return fmt.Errorf("--dry-run and --print cannot be used together")
+			}
+
+			mode := modulepublish.ModeSubmit
+			if dryRun {
+				mode = modulepublish.ModeDryRun
+			} else if printRecords {
+				mode = modulepublish.ModePrint
+			}
+
+			publication, publishErr := service.Publish(
+				command.Context(),
+				modulepublish.Options{Directory: ".", Tag: tag, Mode: mode},
+			)
+
+			if publication != nil {
+				if printRecords {
+					if err := renderModulePublicationJSON(command.OutOrStdout(), publication); err != nil {
+						return err
+					}
+				} else {
+					renderModulePublication(command.OutOrStdout(), publication, mode)
+				}
+			}
+
+			return publishErr
 		},
 	}
 
 	command.Flags().String(moduleTagFlag, "", "Release tag (defaults to v<version> or <source-path>/v<version>)")
+	command.Flags().Bool(moduleDryRunFlag, false, "Validate and prepare the release without submitting to GitHub")
+	command.Flags().Bool(modulePrintFlag, false, "Print deterministic Barn-relative records as JSON without submitting")
 
 	return command
 }

--- a/cmd/internal/mod/command_test.go
+++ b/cmd/internal/mod/command_test.go
@@ -550,10 +550,14 @@ func TestModCommandPublishSubmitsAndRendersProgress(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if service.publishOptions.Tag != "release-1.2.3" || service.publishOptions.Mode != modulepublish.ModeSubmit ||
-		!strings.Contains(output, "✓ Resolved release-1.2.3 → abcdef0") ||
-		!strings.Contains(output, "✓ Submitted to Ferret Registry") ||
-		!strings.Contains(output, service.publication.PullRequestURL) || strings.Contains(output, "registry/modules/") {
+	wantOutput := "✓ Validated ferret.yaml\n" +
+		"✓ Resolved release-1.2.3 → abcdef0\n" +
+		"✓ Verified public source\n" +
+		"✓ Verified README.md and go.mod\n" +
+		"✓ Prepared acme/widget@1.2.3\n" +
+		"✓ Submitted to Ferret Registry\n" +
+		"https://github.com/MontFerret/barn/pull/123\n"
+	if service.publishOptions.Tag != "release-1.2.3" || service.publishOptions.Mode != modulepublish.ModeSubmit || output != wantOutput {
 		t.Fatalf("unexpected publication output:\n%s", output)
 	}
 }
@@ -573,7 +577,14 @@ func TestModCommandPublishReportsExistingSubmission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(output, "✓ Found existing Registry submission") || !strings.Contains(output, service.publication.PullRequestURL) {
+	wantOutput := "✓ Validated ferret.yaml\n" +
+		"✓ Resolved v1.2.3 → abcdef0\n" +
+		"✓ Verified public source\n" +
+		"✓ Verified README.md and go.mod\n" +
+		"✓ Prepared acme/widget@1.2.3\n" +
+		"✓ Found existing Registry submission\n" +
+		"https://github.com/MontFerret/barn/pull/123\n"
+	if output != wantOutput {
 		t.Fatalf("unexpected existing-submission output:\n%s", output)
 	}
 }

--- a/cmd/internal/mod/command_test.go
+++ b/cmd/internal/mod/command_test.go
@@ -3,6 +3,7 @@ package mod
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/MontFerret/cli/v2/pkg/config"
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
+	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
 	"github.com/MontFerret/cli/v2/pkg/module/scaffold"
 )
 
@@ -527,45 +529,177 @@ func TestModCommandInitFullySpecifiedBypassesInteractivePrompt(t *testing.T) {
 	}
 }
 
-func TestModCommandPublishRendersRecords(t *testing.T) {
-	service := &fakeModuleService{publication: &barnpublish.Result{
+func TestModCommandPublishSubmitsAndRendersProgress(t *testing.T) {
+	prepared := &barnpublish.Result{
 		Kind: barnpublish.NewModule,
 		Module: &registryspec.ModuleManifest{
+			Owner: "acme", Name: "widget",
 			Source: registryspec.Source{Repository: "https://example.com/acme/widget", Path: "modules/widget"},
 		},
-		Version: &registryspec.VersionRecord{Version: "1.2.3", Tag: "release-1.2.3", Commit: "abc"},
+		Version: &registryspec.VersionRecord{Version: "1.2.3", Tag: "release-1.2.3", Commit: "abcdef0123456789"},
 		Files: []barnpublish.File{
 			{Path: "registry/modules/acme/widget/manifest.json", Content: []byte("{}\n")},
 			{Path: "registry/modules/acme/widget/versions/v1.2.3.json", Content: []byte("{}\n")},
 		},
+	}
+	service := &fakeModuleService{publication: &modulepublish.Result{
+		Status: modulepublish.StatusSubmitted, Module: "acme/widget", Version: "1.2.3",
+		Tag: "release-1.2.3", Prepared: prepared, PullRequestURL: "https://github.com/MontFerret/barn/pull/123",
 	}}
 	output, err := executeModCommand(t, service, "publish", "--tag", "release-1.2.3")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if service.publishOptions.Tag != "release-1.2.3" || !strings.Contains(output, "Manifest: valid") || !strings.Contains(output, service.publication.Files[1].Path) || !strings.Contains(output, "Add both records") {
+	if service.publishOptions.Tag != "release-1.2.3" || service.publishOptions.Mode != modulepublish.ModeSubmit ||
+		!strings.Contains(output, "✓ Resolved release-1.2.3 → abcdef0") ||
+		!strings.Contains(output, "✓ Submitted to Ferret Registry") ||
+		!strings.Contains(output, service.publication.PullRequestURL) || strings.Contains(output, "registry/modules/") {
 		t.Fatalf("unexpected publication output:\n%s", output)
 	}
 }
 
-func TestModCommandPublishRendersOnlyNewVersionFile(t *testing.T) {
-	service := &fakeModuleService{publication: &barnpublish.Result{
-		Kind: barnpublish.NewVersion,
-		Module: &registryspec.ModuleManifest{
-			Source: registryspec.Source{Repository: "https://example.com/acme/widget"},
+func TestModCommandPublishReportsExistingSubmission(t *testing.T) {
+	service := &fakeModuleService{publication: &modulepublish.Result{
+		Status: modulepublish.StatusExistingSubmission, Module: "acme/widget", Version: "1.2.3",
+		Tag: "v1.2.3", Prepared: &barnpublish.Result{
+			Kind:    barnpublish.NewVersion,
+			Module:  &registryspec.ModuleManifest{Owner: "acme", Name: "widget"},
+			Version: &registryspec.VersionRecord{Version: "1.2.3", Tag: "v1.2.3", Commit: "abcdef0123456789"},
 		},
-		Version: &registryspec.VersionRecord{Version: "1.2.4", Tag: "v1.2.4", Commit: "def"},
-		Files: []barnpublish.File{{
-			Path: "registry/modules/acme/widget/versions/v1.2.4.json", Content: []byte("{\"version\":\"1.2.4\"}\n"),
-		}},
+		PullRequestURL: "https://github.com/MontFerret/barn/pull/123",
 	}}
 
 	output, err := executeModCommand(t, service, "publish")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if service.publishOptions.Tag != "" || strings.Contains(output, "manifest.json") || !strings.Contains(output, service.publication.Files[0].Path) || !strings.Contains(output, "without modifying published records") {
-		t.Fatalf("unexpected new-version output:\n%s", output)
+	if !strings.Contains(output, "✓ Found existing Registry submission") || !strings.Contains(output, service.publication.PullRequestURL) {
+		t.Fatalf("unexpected existing-submission output:\n%s", output)
+	}
+}
+
+func TestModCommandPublishPrintsDeterministicJSON(t *testing.T) {
+	prepared := &barnpublish.Result{
+		Kind: barnpublish.NewModule,
+		Module: &registryspec.ModuleManifest{
+			Owner: "acme", Name: "widget",
+			Source: registryspec.Source{Repository: "https://example.com/acme/widget"},
+		},
+		Version: &registryspec.VersionRecord{Version: "1.2.4", Tag: "v1.2.4", Commit: "def0123456789abc"},
+		Files: []barnpublish.File{
+			{Path: "registry/modules/acme/widget/versions/v1.2.4.json", Content: []byte("{\"version\":\"1.2.4\"}\n")},
+			{Path: "registry/modules/acme/widget/manifest.json", Content: []byte("{\"name\":\"widget\"}\n")},
+		},
+	}
+	service := &fakeModuleService{publication: &modulepublish.Result{
+		Status: modulepublish.StatusReady, Module: "acme/widget", Version: "1.2.4", Tag: "v1.2.4", Prepared: prepared,
+	}}
+
+	output, err := executeModCommand(t, service, "publish", "--print")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	var document publicationDocument
+	if decodeErr := json.Unmarshal([]byte(output), &fields); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if decodeErr := json.Unmarshal([]byte(output), &document); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if service.publishOptions.Mode != modulepublish.ModePrint || strings.Contains(output, "✓") || !strings.HasSuffix(output, "\n") ||
+		len(fields) != 8 || document.SchemaVersion != 1 || document.Status != modulepublish.StatusReady ||
+		document.Module != "acme/widget" || document.Version != "1.2.4" || document.Tag != "v1.2.4" ||
+		document.Kind != string(barnpublish.NewModule) || document.Commit != "def0123456789abc" || len(document.Records) != 2 ||
+		document.Records[0].Path != "registry/modules/acme/widget/manifest.json" || document.Records[0].Content != "{\"name\":\"widget\"}\n" ||
+		document.Records[1].Path != "registry/modules/acme/widget/versions/v1.2.4.json" || document.Records[1].Content != "{\"version\":\"1.2.4\"}\n" {
+		t.Fatalf("unexpected publication JSON:\n%s", output)
+	}
+}
+
+func TestModCommandPublishDryRunAndAlreadyPublished(t *testing.T) {
+	prepared := &barnpublish.Result{
+		Kind:    barnpublish.NewVersion,
+		Module:  &registryspec.ModuleManifest{Owner: "acme", Name: "widget"},
+		Version: &registryspec.VersionRecord{Version: "1.2.4", Tag: "v1.2.4", Commit: "def0123456789abc"},
+	}
+	service := &fakeModuleService{publication: &modulepublish.Result{
+		Status: modulepublish.StatusReady, Module: "acme/widget", Version: "1.2.4", Tag: "v1.2.4", Prepared: prepared,
+	}}
+	output, err := executeModCommand(t, service, "publish", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if service.publishOptions.Mode != modulepublish.ModeDryRun || !strings.Contains(output, "Ready to publish.") {
+		t.Fatalf("unexpected dry-run output:\n%s", output)
+	}
+
+	service.publication = &modulepublish.Result{
+		Status: modulepublish.StatusAlreadyPublished, Module: "acme/widget", Version: "1.2.4", Tag: "v1.2.4",
+	}
+	output, err = executeModCommand(t, service, "publish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "✓ Validated ferret.yaml\nacme/widget@1.2.4 is already published.\n" {
+		t.Fatalf("unexpected already-published output: %q", output)
+	}
+}
+
+func TestModCommandPublishRejectsConflictingModesBeforeService(t *testing.T) {
+	service := &fakeModuleService{}
+	_, err := executeModCommand(t, service, "publish", "--dry-run", "--print")
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("unexpected flag error: %v", err)
+	}
+	if service.publishCalls != 0 {
+		t.Fatalf("service called for conflicting modes: %d", service.publishCalls)
+	}
+}
+
+func TestModCommandPublishRendersPreparedProgressBeforeSubmissionError(t *testing.T) {
+	want := errors.New("create pull request")
+	prepared := &barnpublish.Result{
+		Kind:    barnpublish.NewVersion,
+		Module:  &registryspec.ModuleManifest{Owner: "acme", Name: "widget"},
+		Version: &registryspec.VersionRecord{Version: "1.2.4", Tag: "v1.2.4", Commit: "def0123456789abc"},
+	}
+	service := &fakeModuleService{
+		publication: &modulepublish.Result{
+			Status: modulepublish.StatusReady, Module: "acme/widget", Version: "1.2.4", Tag: "v1.2.4", Prepared: prepared,
+		},
+		err: want,
+	}
+
+	output, err := executeModCommand(t, service, "publish")
+	if !errors.Is(err, want) {
+		t.Fatalf("expected submission error, got %v", err)
+	}
+	if !strings.Contains(output, "✓ Prepared acme/widget@1.2.4") || strings.Contains(output, "Submitted") || strings.Contains(output, "Ready to publish") {
+		t.Fatalf("unexpected partial publication output:\n%s", output)
+	}
+}
+
+func TestModCommandPublishPrintsAlreadyPublishedEnvelope(t *testing.T) {
+	service := &fakeModuleService{publication: &modulepublish.Result{
+		Status: modulepublish.StatusAlreadyPublished, Module: "acme/widget", Version: "1.2.4", Tag: "v1.2.4",
+	}}
+
+	output, err := executeModCommand(t, service, "publish", "--print")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	var document publicationDocument
+	if decodeErr := json.Unmarshal([]byte(output), &fields); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if decodeErr := json.Unmarshal([]byte(output), &document); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if len(fields) != 6 || document.Status != modulepublish.StatusAlreadyPublished || len(document.Records) != 0 ||
+		document.Kind != "" || document.Commit != "" || strings.Contains(output, "✓") || !strings.HasSuffix(output, "\n") {
+		t.Fatalf("unexpected already-published JSON:\n%s", output)
 	}
 }
 

--- a/cmd/internal/mod/fake_service_test.go
+++ b/cmd/internal/mod/fake_service_test.go
@@ -3,8 +3,6 @@ package mod
 import (
 	"context"
 
-	barnpublish "github.com/MontFerret/barn/pkg/publish"
-
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
@@ -16,10 +14,11 @@ type fakeModuleService struct {
 	info            *discovery.ModuleInfo
 	install         *install.Result
 	create          *scaffold.Result
-	publication     *barnpublish.Result
+	publication     *modulepublish.Result
 	createOptions   scaffold.Options
 	installOptions  install.Options
 	publishOptions  modulepublish.Options
+	publishCalls    int
 	createCalls     int
 	installCalls    int
 	installHistory  []install.Options
@@ -58,7 +57,8 @@ func (f *fakeModuleService) Create(_ context.Context, options scaffold.Options) 
 	return f.create, f.err
 }
 
-func (f *fakeModuleService) Publish(_ context.Context, options modulepublish.Options) (*barnpublish.Result, error) {
+func (f *fakeModuleService) Publish(_ context.Context, options modulepublish.Options) (*modulepublish.Result, error) {
 	f.publishOptions = options
+	f.publishCalls++
 	return f.publication, f.err
 }

--- a/cmd/internal/mod/render.go
+++ b/cmd/internal/mod/render.go
@@ -1,8 +1,10 @@
 package mod
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -10,7 +12,26 @@ import (
 
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
+	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
 	"github.com/MontFerret/cli/v2/pkg/module/scaffold"
+)
+
+type (
+	publicationDocument struct {
+		SchemaVersion int                  `json:"schemaVersion"`
+		Status        modulepublish.Status `json:"status"`
+		Module        string               `json:"module"`
+		Version       string               `json:"version"`
+		Tag           string               `json:"tag"`
+		Kind          string               `json:"kind,omitempty"`
+		Commit        string               `json:"commit,omitempty"`
+		Records       []publicationRecord  `json:"records"`
+	}
+
+	publicationRecord struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
 )
 
 func renderModuleSearch(output io.Writer, results []discovery.SearchResult) error {
@@ -103,24 +124,69 @@ func renderModuleInit(output io.Writer, result *scaffold.Result) {
 	fmt.Fprintln(output, "  3. Run go mod tidy when you are ready to resolve dependencies.")
 }
 
-func renderModulePublication(output io.Writer, publication *barnpublish.Result) {
-	fmt.Fprintln(output, "Manifest: valid")
-	fmt.Fprintf(output, "Repository: %s\n", publication.Module.Source.Repository)
-	if publication.Module.Source.Path != "" {
-		fmt.Fprintf(output, "Source path: %s\n", publication.Module.Source.Path)
-	}
-	fmt.Fprintf(output, "Version: %s\n", publication.Version.Version)
-	fmt.Fprintf(output, "Tag: %s\n", publication.Version.Tag)
-	fmt.Fprintf(output, "Commit: %s\n\n", publication.Version.Commit)
+func renderModulePublication(output io.Writer, publication *modulepublish.Result, mode modulepublish.Mode) {
+	if publication.Status == modulepublish.StatusAlreadyPublished {
+		fmt.Fprintln(output, "✓ Validated ferret.yaml")
+		fmt.Fprintf(output, "%s@%s is already published.\n", publication.Module, publication.Version)
 
-	for _, file := range publication.Files {
-		fmt.Fprintf(output, "%s\n%s\n", file.Path, file.Content)
+		return
 	}
 
-	switch publication.Kind {
-	case barnpublish.NewModule:
-		fmt.Fprintln(output, "Add both records to a Barn pull request.")
-	case barnpublish.NewVersion:
-		fmt.Fprintln(output, "Add the new version record to a Barn pull request without modifying published records.")
+	if publication.Prepared == nil {
+		return
 	}
+
+	commit := publication.Prepared.Version.Commit
+	shortCommit := commit
+	if len(shortCommit) > 7 {
+		shortCommit = shortCommit[:7]
+	}
+
+	fmt.Fprintln(output, "✓ Validated ferret.yaml")
+	fmt.Fprintf(output, "✓ Resolved %s → %s\n", publication.Tag, shortCommit)
+	fmt.Fprintln(output, "✓ Verified public source")
+	fmt.Fprintln(output, "✓ Verified README.md and go.mod")
+	fmt.Fprintf(output, "✓ Prepared %s@%s\n", publication.Module, publication.Version)
+
+	switch publication.Status {
+	case modulepublish.StatusReady:
+		if mode == modulepublish.ModeDryRun {
+			fmt.Fprintln(output, "Ready to publish.")
+		}
+	case modulepublish.StatusSubmitted:
+		fmt.Fprintln(output, "✓ Submitted to Ferret Registry")
+		fmt.Fprintln(output, publication.PullRequestURL)
+	case modulepublish.StatusExistingSubmission:
+		fmt.Fprintln(output, "✓ Found existing Registry submission")
+		fmt.Fprintln(output, publication.PullRequestURL)
+	}
+}
+
+func renderModulePublicationJSON(output io.Writer, publication *modulepublish.Result) error {
+	document := publicationDocument{
+		SchemaVersion: 1,
+		Status:        publication.Status,
+		Module:        publication.Module,
+		Version:       publication.Version,
+		Tag:           publication.Tag,
+		Records:       []publicationRecord{},
+	}
+
+	if publication.Prepared != nil {
+		document.Kind = string(publication.Prepared.Kind)
+		document.Commit = publication.Prepared.Version.Commit
+		files := append([]barnpublish.File{}, publication.Prepared.Files...)
+		sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+		document.Records = make([]publicationRecord, len(files))
+
+		for index, file := range files {
+			document.Records[index] = publicationRecord{Path: file.Path, Content: string(file.Content)}
+		}
+	}
+
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(document)
 }

--- a/cmd/internal/mod/service.go
+++ b/cmd/internal/mod/service.go
@@ -3,8 +3,6 @@ package mod
 import (
 	"context"
 
-	barnpublish "github.com/MontFerret/barn/pkg/publish"
-
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
@@ -17,5 +15,5 @@ type Service interface {
 	Info(context.Context, string) (*discovery.ModuleInfo, error)
 	Install(context.Context, install.Options) (*install.Result, error)
 	Create(context.Context, scaffold.Options) (*scaffold.Result, error)
-	Publish(context.Context, modulepublish.Options) (*barnpublish.Result, error)
+	Publish(context.Context, modulepublish.Options) (*modulepublish.Result, error)
 }

--- a/ferret/main.go
+++ b/ferret/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
+	githubpublish "github.com/MontFerret/cli/v2/pkg/module/publish/github"
 	"github.com/MontFerret/cli/v2/pkg/module/scaffold"
 )
 
@@ -60,11 +61,17 @@ func main() {
 	if err != nil {
 		exit(err)
 	}
+
+	registrySubmitter, err := githubpublish.New()
+	if err != nil {
+		exit(err)
+	}
+
 	moduleService := modulelifecycle.NewService(
 		discovery.New(registryClient),
 		install.New(registryClient, nil),
 		scaffold.New(nil),
-		modulepublish.New(registryClient),
+		modulepublish.New(registryClient, registrySubmitter),
 	)
 
 	rootCmd.AddCommand(

--- a/pkg/module/discovery/service.go
+++ b/pkg/module/discovery/service.go
@@ -32,24 +32,23 @@ func (s *Service) Search(ctx context.Context, query string) ([]SearchResult, err
 	group.SetLimit(6)
 
 	for index, summary := range summaries {
-		idx, sum := index, summary
-
+		index, summary := index, summary
 		group.Go(func() error {
-			item, err := s.registry.Module(groupContext, sum.ID)
+			item, err := s.registry.Module(groupContext, summary.ID)
 			if err != nil {
-				return fmt.Errorf("load registry module %q: %w", sum.ID, err)
+				return fmt.Errorf("load registry module %q: %w", summary.ID, err)
 			}
 
 			if len(item.Versions) == 0 {
 				return fmt.Errorf("%w: module %q has no versions", barnregistry.ErrMalformedArtifact, item.ID)
 			}
 
-			version := sum.Latest
+			version := summary.Latest
 			if version == "" {
 				version = item.Versions[0].Version
 			}
 
-			results[idx] = SearchResult{Name: item.ID, Version: version, Description: item.Description}
+			results[index] = SearchResult{Name: item.ID, Version: version, Description: item.Description}
 
 			return nil
 		})

--- a/pkg/module/discovery/service.go
+++ b/pkg/module/discovery/service.go
@@ -32,23 +32,24 @@ func (s *Service) Search(ctx context.Context, query string) ([]SearchResult, err
 	group.SetLimit(6)
 
 	for index, summary := range summaries {
-		index, summary := index, summary
+		idx, sum := index, summary
+
 		group.Go(func() error {
-			item, err := s.registry.Module(groupContext, summary.ID)
+			item, err := s.registry.Module(groupContext, sum.ID)
 			if err != nil {
-				return fmt.Errorf("load registry module %q: %w", summary.ID, err)
+				return fmt.Errorf("load registry module %q: %w", sum.ID, err)
 			}
 
 			if len(item.Versions) == 0 {
 				return fmt.Errorf("%w: module %q has no versions", barnregistry.ErrMalformedArtifact, item.ID)
 			}
 
-			version := summary.Latest
+			version := sum.Latest
 			if version == "" {
 				version = item.Versions[0].Version
 			}
 
-			results[index] = SearchResult{Name: item.ID, Version: version, Description: item.Description}
+			results[idx] = SearchResult{Name: item.ID, Version: version, Description: item.Description}
 
 			return nil
 		})

--- a/pkg/module/publish/fake_submitter_test.go
+++ b/pkg/module/publish/fake_submitter_test.go
@@ -1,0 +1,21 @@
+package publish
+
+import (
+	"context"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+)
+
+type fakeSubmitter struct {
+	submission *Submission
+	prepared   *barnpublish.Result
+	err        error
+	calls      int
+}
+
+func (f *fakeSubmitter) Submit(_ context.Context, prepared *barnpublish.Result) (*Submission, error) {
+	f.calls++
+	f.prepared = prepared
+
+	return f.submission, f.err
+}

--- a/pkg/module/publish/github/api_error.go
+++ b/pkg/module/publish/github/api_error.go
@@ -1,0 +1,22 @@
+package github
+
+import "fmt"
+
+type apiError struct {
+	StatusCode  int
+	Message     string
+	Permissions string
+}
+
+func (e *apiError) Error() string {
+	message := fmt.Sprintf("GitHub API returned HTTP %d", e.StatusCode)
+	if e.Message != "" {
+		message += ": " + e.Message
+	}
+
+	if e.Permissions != "" {
+		message += " (accepted permissions: " + e.Permissions + ")"
+	}
+
+	return message
+}

--- a/pkg/module/publish/github/authentication_error.go
+++ b/pkg/module/publish/github/authentication_error.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+type authenticationError struct {
+	err error
+}
+
+func newAuthenticationError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	var existing *authenticationError
+	if errors.As(err, &existing) {
+		return err
+	}
+
+	return &authenticationError{err: err}
+}
+
+func (e *authenticationError) Error() string {
+	return fmt.Sprintf(
+		"%v; set GH_TOKEN or GITHUB_TOKEN, or run %q",
+		e.err,
+		"gh auth login --hostname github.com",
+	)
+}
+
+func (e *authenticationError) Unwrap() error {
+	return e.err
+}

--- a/pkg/module/publish/github/client.go
+++ b/pkg/module/publish/github/client.go
@@ -1,0 +1,271 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const apiVersion = "2026-03-10"
+
+type client struct {
+	baseURL    string
+	httpClient *http.Client
+	token      string
+}
+
+func newClient(baseURL string, httpClient *http.Client, token string) *client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &client{baseURL: strings.TrimRight(baseURL, "/"), httpClient: httpClient, token: token}
+}
+
+func (c *client) currentUser(ctx context.Context) (*user, error) {
+	result := new(user)
+	if err := c.do(ctx, http.MethodGet, apiPath("user"), nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) repository(ctx context.Context, owner, name string) (*repository, error) {
+	result := new(repository)
+	if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name), nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) reference(ctx context.Context, owner, name, branch string) (*gitReference, error) {
+	result := new(gitReference)
+	if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name, "git", "ref", "heads", branch), nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) gitCommit(ctx context.Context, owner, name, sha string) (*gitCommit, error) {
+	result := new(gitCommit)
+	if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name, "git", "commits", sha), nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) commitDetails(ctx context.Context, owner, name, sha string) (*commitDetails, error) {
+	result := new(commitDetails)
+	if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name, "commits", sha), nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) content(ctx context.Context, owner, name, filename, ref string) ([]byte, error) {
+	query := url.Values{"ref": []string{ref}}
+	result := new(contentResponse)
+	if err := c.do(ctx, http.MethodGet, contentPath(owner, name, filename)+"?"+query.Encode(), nil, result); err != nil {
+		return nil, err
+	}
+
+	if result.Encoding != "base64" {
+		return nil, fmt.Errorf("GitHub returned unsupported content encoding %q", result.Encoding)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(result.Content, "\n", ""))
+	if err != nil {
+		return nil, fmt.Errorf("decode GitHub content for %s: %w", filename, err)
+	}
+
+	return data, nil
+}
+
+func (c *client) pullRequests(ctx context.Context, owner, name, base string) ([]pullRequest, error) {
+	var result []pullRequest
+	for page := 1; ; page++ {
+		query := url.Values{
+			"base":     []string{base},
+			"page":     []string{strconv.Itoa(page)},
+			"per_page": []string{"100"},
+			"state":    []string{"open"},
+		}
+
+		var batch []pullRequest
+		if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name, "pulls")+"?"+query.Encode(), nil, &batch); err != nil {
+			return nil, err
+		}
+
+		result = append(result, batch...)
+		if len(batch) < 100 {
+			return result, nil
+		}
+	}
+}
+
+func (c *client) pullFiles(ctx context.Context, owner, name string, number int) ([]pullFile, error) {
+	var result []pullFile
+
+	for page := 1; ; page++ {
+		query := url.Values{"page": []string{strconv.Itoa(page)}, "per_page": []string{"100"}}
+
+		var batch []pullFile
+		if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name, "pulls", strconv.Itoa(number), "files")+"?"+query.Encode(), nil, &batch); err != nil {
+			return nil, err
+		}
+
+		result = append(result, batch...)
+		if len(batch) < 100 {
+			return result, nil
+		}
+	}
+}
+
+func (c *client) forks(ctx context.Context, owner, name string) ([]repository, error) {
+	var result []repository
+
+	for page := 1; ; page++ {
+		query := url.Values{"page": []string{strconv.Itoa(page)}, "per_page": []string{"100"}}
+		var batch []repository
+		if err := c.do(ctx, http.MethodGet, apiPath("repos", owner, name, "forks")+"?"+query.Encode(), nil, &batch); err != nil {
+			return nil, err
+		}
+
+		result = append(result, batch...)
+		if len(batch) < 100 {
+			return result, nil
+		}
+	}
+}
+
+func (c *client) createFork(ctx context.Context, owner, name string) (*repository, error) {
+	result := new(repository)
+	body := map[string]any{"default_branch_only": true}
+
+	if err := c.do(ctx, http.MethodPost, apiPath("repos", owner, name, "forks"), body, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) createTree(ctx context.Context, owner, name, baseTree string, files []record) (*createdTree, error) {
+	entries := make([]map[string]string, len(files))
+
+	for index, file := range files {
+		entries[index] = map[string]string{
+			"path": file.Path, "mode": "100644", "type": "blob", "content": string(file.Content),
+		}
+	}
+
+	result := new(createdTree)
+	body := map[string]any{"base_tree": baseTree, "tree": entries}
+
+	if err := c.do(ctx, http.MethodPost, apiPath("repos", owner, name, "git", "trees"), body, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) createCommit(ctx context.Context, owner, name, message, tree, parent string) (*createdCommit, error) {
+	result := new(createdCommit)
+	body := map[string]any{"message": message, "tree": tree, "parents": []string{parent}}
+
+	if err := c.do(ctx, http.MethodPost, apiPath("repos", owner, name, "git", "commits"), body, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) createReference(ctx context.Context, owner, name, branch, sha string) error {
+	body := map[string]string{"ref": "refs/heads/" + branch, "sha": sha}
+
+	return c.do(ctx, http.MethodPost, apiPath("repos", owner, name, "git", "refs"), body, new(gitReference))
+}
+
+func (c *client) createPullRequest(ctx context.Context, owner, name, title, body, head, base string) (*pullRequest, error) {
+	result := new(pullRequest)
+	request := map[string]any{
+		"title": title, "body": body, "head": head, "base": base, "maintainer_can_modify": true,
+	}
+
+	if err := c.do(ctx, http.MethodPost, apiPath("repos", owner, name, "pulls"), request, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *client) do(ctx context.Context, method, path string, body, output any) error {
+	var input io.Reader
+
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode GitHub request: %w", err)
+		}
+
+		input = bytes.NewReader(data)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, input)
+	if err != nil {
+		return fmt.Errorf("create GitHub request: %w", err)
+	}
+
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("Authorization", "Bearer "+c.token)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "ferret-cli")
+	request.Header.Set("X-GitHub-Api-Version", apiVersion)
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("send GitHub request: %w", err)
+	}
+
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(response.Body, 4<<20))
+	if err != nil {
+		return fmt.Errorf("read GitHub response: %w", err)
+	}
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		var document struct {
+			Message string `json:"message"`
+		}
+
+		_ = json.Unmarshal(data, &document)
+
+		return &apiError{
+			StatusCode:  response.StatusCode,
+			Message:     document.Message,
+			Permissions: response.Header.Get("X-Accepted-GitHub-Permissions"),
+		}
+	}
+
+	if output == nil || len(data) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(data, output); err != nil {
+		return fmt.Errorf("decode GitHub response: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/module/publish/github/client_pagination_test.go
+++ b/pkg/module/publish/github/client_pagination_test.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestClientPaginatesGitHubCollections(t *testing.T) {
+	t.Run("pull requests", func(t *testing.T) {
+		pages := 0
+		transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+			pages++
+			if request.URL.Query().Get("page") == "1" {
+				return jsonResponse(http.StatusOK, make([]pullRequest, 100)), nil
+			}
+
+			return jsonResponse(http.StatusOK, []pullRequest{{Number: 101}}), nil
+		}}
+		client := newClient("https://api.github.test", &http.Client{Transport: transport}, "secret")
+
+		items, err := client.pullRequests(context.Background(), upstreamOwner, upstreamName, "main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 101 || items[100].Number != 101 || pages != 2 {
+			t.Fatalf("unexpected pagination result: len=%d pages=%d", len(items), pages)
+		}
+	})
+
+	t.Run("pull request files", func(t *testing.T) {
+		pages := 0
+		transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+			pages++
+			if request.URL.Query().Get("page") == "1" {
+				return jsonResponse(http.StatusOK, make([]pullFile, 100)), nil
+			}
+
+			return jsonResponse(http.StatusOK, []pullFile{{Filename: "last.json"}}), nil
+		}}
+		client := newClient("https://api.github.test", &http.Client{Transport: transport}, "secret")
+
+		items, err := client.pullFiles(context.Background(), upstreamOwner, upstreamName, 7)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 101 || items[100].Filename != "last.json" || pages != 2 {
+			t.Fatalf("unexpected pagination result: len=%d pages=%d", len(items), pages)
+		}
+	})
+
+	t.Run("forks", func(t *testing.T) {
+		pages := 0
+		transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+			pages++
+			if request.URL.Query().Get("page") == "1" {
+				return jsonResponse(http.StatusOK, make([]repository, 100)), nil
+			}
+
+			return jsonResponse(http.StatusOK, []repository{{FullName: "alice/barn"}}), nil
+		}}
+		client := newClient("https://api.github.test", &http.Client{Transport: transport}, "secret")
+
+		items, err := client.forks(context.Background(), upstreamOwner, upstreamName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 101 || items[100].FullName != "alice/barn" || pages != 2 {
+			t.Fatalf("unexpected pagination result: len=%d pages=%d", len(items), pages)
+		}
+	})
+}

--- a/pkg/module/publish/github/command.go
+++ b/pkg/module/publish/github/command.go
@@ -1,0 +1,11 @@
+package github
+
+import (
+	"context"
+)
+
+type commandRunnerFunc func(context.Context, string, ...string) ([]byte, error)
+
+func (f commandRunnerFunc) Run(ctx context.Context, name string, arguments ...string) ([]byte, error) {
+	return f(ctx, name, arguments...)
+}

--- a/pkg/module/publish/github/doc.go
+++ b/pkg/module/publish/github/doc.go
@@ -1,0 +1,3 @@
+// Package github submits prepared Ferret Registry records through GitHub's
+// fork-and-pull-request workflow.
+package github

--- a/pkg/module/publish/github/error_helpers.go
+++ b/pkg/module/publish/github/error_helpers.go
@@ -1,0 +1,13 @@
+package github
+
+import "errors"
+
+func stageError(stage Stage, err error) error {
+	return &Error{Stage: stage, Err: err}
+}
+
+func hasStatus(err error, status int) bool {
+	var target *apiError
+
+	return errors.As(err, &target) && target.StatusCode == status
+}

--- a/pkg/module/publish/github/errors.go
+++ b/pkg/module/publish/github/errors.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrImmutableConflict reports an existing Registry record with different bytes.
+	ErrImmutableConflict = errors.New("immutable Registry record conflicts with the prepared release")
+	// ErrBranchConflict reports a retry branch that is not the exact prepared change.
+	ErrBranchConflict = errors.New("publication branch already exists with different content")
+	// ErrPullConflict reports an open pull request for the same version with different changes.
+	ErrPullConflict = errors.New("an open Registry pull request conflicts with the prepared release")
+)
+
+type (
+	// Stage identifies the GitHub submission operation that failed.
+	Stage string
+
+	// Error adds a stable submission stage while preserving the underlying error.
+	Error struct {
+		Stage Stage
+		Err   error
+	}
+)
+
+const (
+	// StageAuthentication resolves and validates the GitHub credential.
+	StageAuthentication Stage = "authentication"
+	// StageRepository resolves the canonical Barn base branch and commit.
+	StageRepository Stage = "repository"
+	// StageRecords reconciles prepared records against canonical Barn state.
+	StageRecords Stage = "records"
+	// StagePullRequest finds or creates the focused Barn pull request.
+	StagePullRequest Stage = "pull request"
+	// StageFork finds, creates, and waits for the personal Barn fork.
+	StageFork Stage = "fork"
+	// StageBranch validates or creates the deterministic publication branch.
+	StageBranch Stage = "branch"
+	// StageTree creates the exact Git tree containing the pending records.
+	StageTree Stage = "tree"
+	// StageCommit creates the publication commit from the canonical Barn base.
+	StageCommit Stage = "commit"
+)
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("submit Registry publication at %s stage: %v", e.Stage, e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}

--- a/pkg/module/publish/github/failure_transport_helpers_test.go
+++ b/pkg/module/publish/github/failure_transport_helpers_test.go
@@ -1,0 +1,63 @@
+package github
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func submissionFailureTransport(t *testing.T, failure string) *scriptedTransport {
+	t.Helper()
+
+	return &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, []pullRequest{}), nil
+		case path == "/repos/MontFerret/barn/forks":
+			if failure == "fork" {
+				return apiFailure(http.StatusInternalServerError, "fork failed"), nil
+			}
+
+			return jsonResponse(http.StatusOK, []repository{{FullName: "alice/barn", Owner: user{Login: "alice"}}}), nil
+		case path == "/repos/alice/barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "alice/barn", Permissions: permissions{Push: true}}), nil
+		case strings.HasPrefix(path, "/repos/alice/barn/git/ref/heads/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/alice/barn/git/trees":
+			if failure == "tree" {
+				return apiFailure(http.StatusInternalServerError, "tree failed"), nil
+			}
+
+			return jsonResponse(http.StatusCreated, createdTree{SHA: "new-tree"}), nil
+		case path == "/repos/alice/barn/git/commits":
+			if failure == "commit" {
+				return apiFailure(http.StatusInternalServerError, "commit failed"), nil
+			}
+
+			return jsonResponse(http.StatusCreated, createdCommit{SHA: "new-commit"}), nil
+		case path == "/repos/alice/barn/git/refs":
+			if failure == "reference" {
+				return apiFailure(http.StatusInternalServerError, "reference failed"), nil
+			}
+
+			return jsonResponse(http.StatusCreated, gitReference{}), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodPost:
+			return apiFailure(http.StatusInternalServerError, "pull request failed"), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+}

--- a/pkg/module/publish/github/fake_token_test.go
+++ b/pkg/module/publish/github/fake_token_test.go
@@ -1,0 +1,15 @@
+package github
+
+import "context"
+
+type fakeTokenProvider struct {
+	token string
+	err   error
+	calls int
+}
+
+func (provider *fakeTokenProvider) Token(context.Context) (string, error) {
+	provider.calls++
+
+	return provider.token, provider.err
+}

--- a/pkg/module/publish/github/http_test_helpers_test.go
+++ b/pkg/module/publish/github/http_test_helpers_test.go
@@ -1,0 +1,58 @@
+package github
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sort"
+	"testing"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+	registryspec "github.com/MontFerret/specs/pkg/registry"
+)
+
+func jsonResponse(status int, value any) *http.Response {
+	data, _ := json.Marshal(value)
+
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(data)),
+	}
+}
+
+func apiFailure(status int, message string) *http.Response {
+	return jsonResponse(status, map[string]string{"message": message})
+}
+
+func encodedContent(data []byte) map[string]string {
+	return map[string]string{"encoding": "base64", "content": base64.StdEncoding.EncodeToString(data)}
+}
+
+func testPublication(kind barnpublish.Kind) *barnpublish.Result {
+	module := &registryspec.ModuleManifest{
+		Owner: "acme", Name: "widget",
+		Source: registryspec.Source{Repository: "https://github.com/acme/widget", Path: "modules/widget"},
+	}
+	version := &registryspec.VersionRecord{
+		Version: "1.2.3", Tag: "modules/widget/v1.2.3", Commit: "abcdef0123456789abcdef0123456789abcdef01",
+	}
+	modulePath := "registry/modules/acme/widget/manifest.json"
+	versionPath := "registry/modules/acme/widget/versions/v1.2.3.json"
+	files := []barnpublish.File{{Path: versionPath, Content: []byte("{\"version\":\"1.2.3\"}\n")}}
+	if kind == barnpublish.NewModule {
+		files = append(files, barnpublish.File{Path: modulePath, Content: []byte("{\"owner\":\"acme\"}\n")})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
+	return &barnpublish.Result{Kind: kind, Module: module, Version: version, Files: files}
+}
+
+func readJSONBody(t *testing.T, request *http.Request, target any) {
+	t.Helper()
+	if err := json.NewDecoder(request.Body).Decode(target); err != nil {
+		t.Fatalf("decode %s %s body: %v", request.Method, request.URL, err)
+	}
+}

--- a/pkg/module/publish/github/options.go
+++ b/pkg/module/publish/github/options.go
@@ -1,0 +1,78 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultAPIURL = "https://api.github.com"
+
+type (
+	Option func(*submitterOptions) error
+
+	submitterOptions struct {
+		apiURL       string
+		httpClient   *http.Client
+		pollInterval time.Duration
+		token        TokenProvider
+	}
+)
+
+// WithAPIURL overrides the GitHub API root for testing or compatible proxies.
+func WithAPIURL(value string) Option {
+	return func(options *submitterOptions) error {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("GitHub API URL must not be empty")
+		}
+		options.apiURL = value
+
+		return nil
+	}
+}
+
+// WithHTTPClient injects the transport used for GitHub requests.
+func WithHTTPClient(value *http.Client) Option {
+	return func(options *submitterOptions) error {
+		if value == nil {
+			return fmt.Errorf("GitHub HTTP client must not be nil")
+		}
+		options.httpClient = value
+
+		return nil
+	}
+}
+
+// WithPollInterval overrides the delay used while an asynchronous fork becomes ready.
+func WithPollInterval(value time.Duration) Option {
+	return func(options *submitterOptions) error {
+		if value <= 0 {
+			return fmt.Errorf("GitHub poll interval must be positive")
+		}
+		options.pollInterval = value
+
+		return nil
+	}
+}
+
+// WithTokenProvider injects the GitHub credential resolver.
+func WithTokenProvider(value TokenProvider) Option {
+	return func(options *submitterOptions) error {
+		if value == nil {
+			return fmt.Errorf("GitHub token provider must not be nil")
+		}
+		options.token = value
+
+		return nil
+	}
+}
+
+func defaultSubmitterOptions() submitterOptions {
+	return submitterOptions{
+		apiURL:       defaultAPIURL,
+		httpClient:   http.DefaultClient,
+		pollInterval: 500 * time.Millisecond,
+		token:        NewTokenSource(),
+	}
+}

--- a/pkg/module/publish/github/options.go
+++ b/pkg/module/publish/github/options.go
@@ -7,7 +7,10 @@ import (
 	"time"
 )
 
-const defaultAPIURL = "https://api.github.com"
+const (
+	defaultAPIURL      = "https://api.github.com"
+	defaultHTTPTimeout = 30 * time.Second
+)
 
 type (
 	Option func(*submitterOptions) error
@@ -71,7 +74,7 @@ func WithTokenProvider(value TokenProvider) Option {
 func defaultSubmitterOptions() submitterOptions {
 	return submitterOptions{
 		apiURL:       defaultAPIURL,
-		httpClient:   http.DefaultClient,
+		httpClient:   &http.Client{Timeout: defaultHTTPTimeout},
 		pollInterval: 500 * time.Millisecond,
 		token:        NewTokenSource(),
 	}

--- a/pkg/module/publish/github/options_test.go
+++ b/pkg/module/publish/github/options_test.go
@@ -1,0 +1,13 @@
+package github
+
+import "testing"
+
+func TestDefaultSubmitterOptionsUseBoundedHTTPClient(t *testing.T) {
+	options := defaultSubmitterOptions()
+	if options.httpClient == nil {
+		t.Fatal("default HTTP client is nil")
+	}
+	if options.httpClient.Timeout != defaultHTTPTimeout {
+		t.Fatalf("default HTTP timeout = %v, want %v", options.httpClient.Timeout, defaultHTTPTimeout)
+	}
+}

--- a/pkg/module/publish/github/paths.go
+++ b/pkg/module/publish/github/paths.go
@@ -1,0 +1,29 @@
+package github
+
+import (
+	"net/url"
+	"strings"
+)
+
+func apiPath(parts ...string) string {
+	escaped := make([]string, len(parts))
+
+	for index, part := range parts {
+		escaped[index] = url.PathEscape(part)
+	}
+
+	return "/" + strings.Join(escaped, "/")
+}
+
+func contentPath(owner, repositoryName, filename string) string {
+	parts := []string{"repos", owner, repositoryName, "contents"}
+	parts = append(parts, strings.Split(filename, "/")...)
+
+	return apiPath(parts...)
+}
+
+func splitRepository(fullName string) (string, string, bool) {
+	owner, name, found := strings.Cut(fullName, "/")
+
+	return owner, name, found && owner != "" && name != "" && !strings.Contains(name, "/")
+}

--- a/pkg/module/publish/github/pull_request_test.go
+++ b/pkg/module/publish/github/pull_request_test.go
@@ -51,6 +51,50 @@ func TestSubmitterRejectsConflictingPullRequest(t *testing.T) {
 	}
 }
 
+func TestSubmitterPreservesPullRequestContentReadFailure(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	records, versionPath, err := publicationRecords(publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case "/repos/MontFerret/barn/pulls":
+			return jsonResponse(http.StatusOK, []pullRequest{{
+				Number: 13, HTMLURL: "https://github.com/MontFerret/barn/pull/13",
+				Head: pullHead{SHA: "head", Repo: &repository{FullName: "alice/barn"}},
+			}}), nil
+		case "/repos/MontFerret/barn/pulls/13/files":
+			return jsonResponse(http.StatusOK, []pullFile{{Filename: versionPath, Status: "added"}}), nil
+		default:
+			if strings.Contains(request.URL.Path, "/repos/alice/barn/contents/") {
+				return apiFailure(http.StatusInternalServerError, "content unavailable"), nil
+			}
+
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(WithHTTPClient(&http.Client{Transport: transport}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.findPullRequest(
+		context.Background(),
+		newClient("https://api.github.test", &http.Client{Transport: transport}, "secret"),
+		"main",
+		records,
+		versionPath,
+	)
+	if err == nil || errors.Is(err, ErrPullConflict) ||
+		!strings.Contains(err.Error(), "read pull request record "+versionPath) ||
+		!strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("unexpected pull request content failure: %v", err)
+	}
+}
+
 func TestSubmitterRecoversPullRequestCreationRace(t *testing.T) {
 	publication := testPublication(barnpublish.NewVersion)
 	versionFile := publication.Files[0]

--- a/pkg/module/publish/github/pull_request_test.go
+++ b/pkg/module/publish/github/pull_request_test.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+)
+
+func TestSubmitterRejectsConflictingPullRequest(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	records, versionPath, err := publicationRecords(publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case "/repos/MontFerret/barn/pulls":
+			return jsonResponse(http.StatusOK, []pullRequest{{
+				Number: 12, HTMLURL: "https://github.com/MontFerret/barn/pull/12",
+				Head: pullHead{SHA: "head", Repo: &repository{FullName: "alice/barn"}},
+			}}), nil
+		case "/repos/MontFerret/barn/pulls/12/files":
+			return jsonResponse(http.StatusOK, []pullFile{
+				{Filename: versionPath, Status: "added"},
+				{Filename: "README.md", Status: "modified"},
+			}), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(WithHTTPClient(&http.Client{Transport: transport}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.findPullRequest(
+		context.Background(),
+		newClient("https://api.github.test", &http.Client{Transport: transport}, "secret"),
+		"main",
+		records,
+		versionPath,
+	)
+	if !errors.Is(err, ErrPullConflict) || !strings.Contains(err.Error(), "https://github.com/MontFerret/barn/pull/12") {
+		t.Fatalf("unexpected pull request conflict: %v", err)
+	}
+}
+
+func TestSubmitterRecoversPullRequestCreationRace(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	versionFile := publication.Files[0]
+	pullLookups := 0
+	mutations := make([]string, 0, 4)
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodGet:
+			pullLookups++
+			if pullLookups == 1 {
+				return jsonResponse(http.StatusOK, []pullRequest{}), nil
+			}
+
+			return jsonResponse(http.StatusOK, []pullRequest{{
+				Number: 44, HTMLURL: "https://github.com/MontFerret/barn/pull/44",
+				Head: pullHead{SHA: "branch-commit", Repo: &repository{FullName: "alice/barn"}},
+			}}), nil
+		case path == "/repos/MontFerret/barn/pulls/44/files":
+			return jsonResponse(http.StatusOK, []pullFile{{Filename: versionFile.Path, Status: "added"}}), nil
+		case strings.Contains(path, "/repos/alice/barn/contents/"):
+			return jsonResponse(http.StatusOK, encodedContent(versionFile.Content)), nil
+		case path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusOK, []repository{{FullName: "alice/barn", Owner: user{Login: "alice"}}}), nil
+		case path == "/repos/alice/barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "alice/barn", Permissions: permissions{Push: true}}), nil
+		case strings.HasPrefix(path, "/repos/alice/barn/git/ref/heads/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/alice/barn/git/trees":
+			mutations = append(mutations, "tree")
+
+			return jsonResponse(http.StatusCreated, createdTree{SHA: "new-tree"}), nil
+		case path == "/repos/alice/barn/git/commits":
+			mutations = append(mutations, "commit")
+
+			return jsonResponse(http.StatusCreated, createdCommit{SHA: "branch-commit"}), nil
+		case path == "/repos/alice/barn/git/refs":
+			mutations = append(mutations, "reference")
+
+			return jsonResponse(http.StatusCreated, gitReference{}), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodPost:
+			mutations = append(mutations, "pull")
+
+			return apiFailure(http.StatusUnprocessableEntity, "pull request already exists"), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := submitter.Submit(context.Background(), publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.URL != "https://github.com/MontFerret/barn/pull/44" || !result.Existing || pullLookups != 2 || strings.Join(mutations, ",") != "tree,commit,reference,pull" {
+		t.Fatalf("unexpected race recovery: result=%#v lookups=%d mutations=%v", result, pullLookups, mutations)
+	}
+}

--- a/pkg/module/publish/github/records.go
+++ b/pkg/module/publish/github/records.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+)
+
+type record struct {
+	Path    string
+	Content []byte
+}
+
+func publicationRecords(publication *barnpublish.Result) ([]record, string, error) {
+	if publication == nil || publication.Module == nil || publication.Version == nil {
+		return nil, "", fmt.Errorf("prepared publication is incomplete")
+	}
+
+	if len(publication.Version.Commit) < 8 {
+		return nil, "", fmt.Errorf("prepared publication commit is incomplete")
+	}
+
+	if publication.Kind != barnpublish.NewVersion {
+		return nil, "", fmt.Errorf("prepared publication kind %q is unsupported", publication.Kind)
+	}
+
+	moduleRoot := path.Join("registry", "modules", publication.Module.Owner, publication.Module.Name)
+	manifestPath := path.Join(moduleRoot, "manifest.json")
+	versionPath := path.Join(moduleRoot, "versions", "v"+publication.Version.Version+".json")
+
+	allowed := map[string]bool{versionPath: true}
+	allowed[manifestPath] = true
+	records := make([]record, 0, len(publication.Files))
+	seen := make(map[string]struct{}, len(publication.Files))
+
+	for _, file := range publication.Files {
+		clean := path.Clean(file.Path)
+		if clean != file.Path || strings.HasPrefix(clean, "../") || !allowed[clean] {
+			return nil, "", fmt.Errorf("prepared publication contains unexpected path %q", file.Path)
+		}
+
+		if _, exists := seen[clean]; exists {
+			return nil, "", fmt.Errorf("prepared publication contains duplicate path %q", clean)
+		}
+
+		seen[clean] = struct{}{}
+		if bytes.Contains(file.Content, []byte(`"publishedAt"`)) {
+			var document map[string]json.RawMessage
+			if err := json.Unmarshal(file.Content, &document); err != nil {
+				return nil, "", fmt.Errorf("parse prepared record %s: %w", clean, err)
+			}
+
+			if _, exists := document["publishedAt"]; exists {
+				return nil, "", fmt.Errorf("prepared publication must not contain publishedAt in %s", clean)
+			}
+		}
+
+		records = append(records, record{Path: clean, Content: append([]byte{}, file.Content...)})
+	}
+	if len(records) != len(allowed) {
+		return nil, "", fmt.Errorf("prepared publication contains %d records, want %d", len(records), len(allowed))
+	}
+
+	sort.Slice(records, func(i, j int) bool { return records[i].Path < records[j].Path })
+
+	return records, versionPath, nil
+}
+
+func sameRecordSet(files []pullFile, records []record) bool {
+	if len(files) != len(records) {
+		return false
+	}
+
+	expected := make(map[string]struct{}, len(records))
+	for _, item := range records {
+		expected[item.Path] = struct{}{}
+	}
+
+	for _, file := range files {
+		if file.Status != "added" {
+			return false
+		}
+
+		if _, exists := expected[file.Filename]; !exists {
+			return false
+		}
+
+		delete(expected, file.Filename)
+	}
+
+	return len(expected) == 0
+}

--- a/pkg/module/publish/github/records.go
+++ b/pkg/module/publish/github/records.go
@@ -25,16 +25,20 @@ func publicationRecords(publication *barnpublish.Result) ([]record, string, erro
 		return nil, "", fmt.Errorf("prepared publication commit is incomplete")
 	}
 
-	if publication.Kind != barnpublish.NewVersion {
-		return nil, "", fmt.Errorf("prepared publication kind %q is unsupported", publication.Kind)
-	}
-
 	moduleRoot := path.Join("registry", "modules", publication.Module.Owner, publication.Module.Name)
 	manifestPath := path.Join(moduleRoot, "manifest.json")
 	versionPath := path.Join(moduleRoot, "versions", "v"+publication.Version.Version+".json")
 
 	allowed := map[string]bool{versionPath: true}
-	allowed[manifestPath] = true
+
+	switch publication.Kind {
+	case barnpublish.NewModule:
+		allowed[manifestPath] = true
+	case barnpublish.NewVersion:
+	default:
+		return nil, "", fmt.Errorf("prepared publication kind %q is unsupported", publication.Kind)
+	}
+
 	records := make([]record, 0, len(publication.Files))
 	seen := make(map[string]struct{}, len(publication.Files))
 

--- a/pkg/module/publish/github/records_test.go
+++ b/pkg/module/publish/github/records_test.go
@@ -1,11 +1,62 @@
 package github
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	barnpublish "github.com/MontFerret/barn/pkg/publish"
 )
+
+func TestPublicationRecordsAcceptBarnRecordShapes(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		kind      barnpublish.Kind
+		wantPaths []string
+	}{
+		{
+			name: "new module",
+			kind: barnpublish.NewModule,
+			wantPaths: []string{
+				"registry/modules/acme/widget/manifest.json",
+				"registry/modules/acme/widget/versions/v1.2.3.json",
+			},
+		},
+		{
+			name:      "new version",
+			kind:      barnpublish.NewVersion,
+			wantPaths: []string{"registry/modules/acme/widget/versions/v1.2.3.json"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			publication := testPublication(test.kind)
+			records, versionPath, err := publicationRecords(publication)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if versionPath != "registry/modules/acme/widget/versions/v1.2.3.json" || len(records) != len(test.wantPaths) {
+				t.Fatalf("unexpected publication records: versionPath=%q records=%#v", versionPath, records)
+			}
+
+			for index, wantPath := range test.wantPaths {
+				if records[index].Path != wantPath {
+					t.Fatalf("record %d path = %q, want %q", index, records[index].Path, wantPath)
+				}
+
+				var wantContent []byte
+				for _, file := range publication.Files {
+					if file.Path == wantPath {
+						wantContent = file.Content
+						break
+					}
+				}
+				if !bytes.Equal(records[index].Content, wantContent) {
+					t.Fatalf("record %s did not preserve prepared bytes", wantPath)
+				}
+			}
+		})
+	}
+}
 
 func TestPublicationRecordsRejectUnexpectedAndStampedFiles(t *testing.T) {
 	for _, test := range []struct {
@@ -26,6 +77,20 @@ func TestPublicationRecordsRejectUnexpectedAndStampedFiles(t *testing.T) {
 				publication.Files[1].Content = []byte("{\"publishedAt\":\"2026-08-09T00:00:00Z\"}\n")
 			},
 			message: "must not contain publishedAt",
+		},
+		{
+			name: "duplicate path",
+			mutate: func(publication *barnpublish.Result) {
+				publication.Files = append(publication.Files, publication.Files[0])
+			},
+			message: "duplicate path",
+		},
+		{
+			name: "unknown kind",
+			mutate: func(publication *barnpublish.Result) {
+				publication.Kind = barnpublish.Kind("future-kind")
+			},
+			message: "unsupported",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/module/publish/github/records_test.go
+++ b/pkg/module/publish/github/records_test.go
@@ -1,0 +1,41 @@
+package github
+
+import (
+	"strings"
+	"testing"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+)
+
+func TestPublicationRecordsRejectUnexpectedAndStampedFiles(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mutate  func(*barnpublish.Result)
+		message string
+	}{
+		{
+			name: "unexpected path",
+			mutate: func(publication *barnpublish.Result) {
+				publication.Files[1].Path = "dist/modules/acme/widget.json"
+			},
+			message: "unexpected path",
+		},
+		{
+			name: "publication timestamp",
+			mutate: func(publication *barnpublish.Result) {
+				publication.Files[1].Content = []byte("{\"publishedAt\":\"2026-08-09T00:00:00Z\"}\n")
+			},
+			message: "must not contain publishedAt",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			publication := testPublication(barnpublish.NewModule)
+			test.mutate(publication)
+
+			_, _, err := publicationRecords(publication)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/module/publish/github/scripted_transport_test.go
+++ b/pkg/module/publish/github/scripted_transport_test.go
@@ -1,0 +1,11 @@
+package github
+
+import "net/http"
+
+type scriptedTransport struct {
+	handle func(*http.Request) (*http.Response, error)
+}
+
+func (transport *scriptedTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	return transport.handle(request)
+}

--- a/pkg/module/publish/github/submitter.go
+++ b/pkg/module/publish/github/submitter.go
@@ -57,17 +57,23 @@ func (s *Submitter) Submit(ctx context.Context, publication *barnpublish.Result)
 
 	token, err := s.token.Token(ctx)
 	if err != nil {
-		return nil, stageError(StageAuthentication, err)
+		return nil, stageError(StageAuthentication, newAuthenticationError(err))
 	}
 
 	client := newClient(s.apiURL, s.httpClient, token)
 	currentUser, err := client.currentUser(ctx)
 	if err != nil {
-		return nil, stageError(StageAuthentication, err)
+		return nil, stageError(
+			StageAuthentication,
+			newAuthenticationError(fmt.Errorf("validate GitHub credential: %w", err)),
+		)
 	}
 
 	if currentUser.Login == "" {
-		return nil, stageError(StageAuthentication, errors.New("GitHub returned no authenticated user login"))
+		return nil, stageError(
+			StageAuthentication,
+			newAuthenticationError(errors.New("GitHub returned no authenticated user login")),
+		)
 	}
 
 	upstream, err := client.repository(ctx, upstreamOwner, upstreamName)
@@ -275,7 +281,11 @@ func (s *Submitter) findPullRequest(ctx context.Context, client *client, base st
 
 		for _, item := range records {
 			content, err := client.content(ctx, headOwner, headName, item.Path, pull.Head.SHA)
-			if err != nil || !bytes.Equal(content, item.Content) {
+			if err != nil {
+				return nil, fmt.Errorf("read pull request record %s from %s: %w", item.Path, pull.HTMLURL, err)
+			}
+
+			if !bytes.Equal(content, item.Content) {
 				return nil, fmt.Errorf("%w: %s", ErrPullConflict, pull.HTMLURL)
 			}
 		}
@@ -361,7 +371,11 @@ func (s *Submitter) existingBranch(ctx context.Context, client *client, owner, n
 
 	for _, item := range records {
 		content, err := client.content(ctx, owner, name, item.Path, reference.Object.SHA)
-		if err != nil || !bytes.Equal(content, item.Content) {
+		if err != nil {
+			return false, fmt.Errorf("read publication branch record %s from %s/%s: %w", item.Path, owner, name, err)
+		}
+
+		if !bytes.Equal(content, item.Content) {
 			return false, fmt.Errorf("%w: %s; delete the branch from %s/%s and retry", ErrBranchConflict, branch, owner, name)
 		}
 	}

--- a/pkg/module/publish/github/submitter.go
+++ b/pkg/module/publish/github/submitter.go
@@ -1,0 +1,370 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+
+	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
+)
+
+const (
+	upstreamOwner = "MontFerret"
+	upstreamName  = "barn"
+	forkTimeout   = 30 * time.Second
+)
+
+// Submitter creates focused Ferret Registry pull requests through GitHub.
+type Submitter struct {
+	apiURL       string
+	httpClient   *http.Client
+	pollInterval time.Duration
+	token        TokenProvider
+}
+
+// New constructs a GitHub Registry submitter.
+func New(setters ...Option) (*Submitter, error) {
+	options := defaultSubmitterOptions()
+
+	for _, setter := range setters {
+		if setter == nil {
+			continue
+		}
+
+		if err := setter(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Submitter{
+		apiURL: options.apiURL, httpClient: options.httpClient,
+		pollInterval: options.pollInterval, token: options.token,
+	}, nil
+}
+
+// Submit creates or recovers the pull request for a prepared Barn publication.
+func (s *Submitter) Submit(ctx context.Context, publication *barnpublish.Result) (*modulepublish.Submission, error) {
+	records, versionPath, err := publicationRecords(publication)
+	if err != nil {
+		return nil, stageError(StageRecords, err)
+	}
+
+	token, err := s.token.Token(ctx)
+	if err != nil {
+		return nil, stageError(StageAuthentication, err)
+	}
+
+	client := newClient(s.apiURL, s.httpClient, token)
+	currentUser, err := client.currentUser(ctx)
+	if err != nil {
+		return nil, stageError(StageAuthentication, err)
+	}
+
+	if currentUser.Login == "" {
+		return nil, stageError(StageAuthentication, errors.New("GitHub returned no authenticated user login"))
+	}
+
+	upstream, err := client.repository(ctx, upstreamOwner, upstreamName)
+	if err != nil {
+		return nil, stageError(StageRepository, fmt.Errorf("load %s/%s: %w", upstreamOwner, upstreamName, err))
+	}
+
+	if upstream.DefaultBranch == "" {
+		return nil, stageError(StageRepository, errors.New("canonical repository has no default branch"))
+	}
+
+	baseReference, err := client.reference(ctx, upstreamOwner, upstreamName, upstream.DefaultBranch)
+	if err != nil {
+		return nil, stageError(StageRepository, fmt.Errorf("resolve upstream branch %q: %w", upstream.DefaultBranch, err))
+	}
+
+	if baseReference.Object.SHA == "" {
+		return nil, stageError(StageRepository, fmt.Errorf("upstream branch %q has no commit", upstream.DefaultBranch))
+	}
+
+	baseCommit, err := client.gitCommit(ctx, upstreamOwner, upstreamName, baseReference.Object.SHA)
+	if err != nil {
+		return nil, stageError(StageRepository, fmt.Errorf("load upstream commit %s: %w", baseReference.Object.SHA, err))
+	}
+
+	if baseCommit.Tree.SHA == "" {
+		return nil, stageError(StageRepository, fmt.Errorf("upstream commit %s has no tree", baseReference.Object.SHA))
+	}
+
+	pending, err := s.reconcile(ctx, client, baseReference.Object.SHA, records)
+	if err != nil {
+		return nil, stageError(StageRecords, err)
+	}
+
+	if len(pending) == 0 {
+		return &modulepublish.Submission{AlreadyPublished: true}, nil
+	}
+
+	existing, err := s.findPullRequest(ctx, client, upstream.DefaultBranch, pending, versionPath)
+	if err != nil {
+		return nil, stageError(StagePullRequest, err)
+	}
+
+	if existing != nil {
+		return &modulepublish.Submission{URL: existing.HTMLURL, Existing: true}, nil
+	}
+
+	fork, err := s.fork(ctx, client, currentUser.Login)
+	if err != nil {
+		return nil, stageError(StageFork, err)
+	}
+
+	forkOwner, forkName, valid := splitRepository(fork.FullName)
+	if !valid {
+		return nil, stageError(StageFork, fmt.Errorf("GitHub returned invalid fork identity %q", fork.FullName))
+	}
+
+	branch := fmt.Sprintf(
+		"ferret-publish/%s-%s-v%s-%s",
+		publication.Module.Owner,
+		publication.Module.Name,
+		publication.Version.Version,
+		publication.Version.Commit[:8],
+	)
+
+	reused, err := s.existingBranch(ctx, client, forkOwner, forkName, branch, baseReference.Object.SHA, pending)
+	if err != nil {
+		return nil, stageError(StageBranch, err)
+	}
+
+	title := fmt.Sprintf("Publish %s/%s@%s", publication.Module.Owner, publication.Module.Name, publication.Version.Version)
+	if !reused {
+		tree, err := client.createTree(ctx, forkOwner, forkName, baseCommit.Tree.SHA, pending)
+		if err != nil {
+			return nil, stageError(StageTree, err)
+		}
+
+		if tree.SHA == "" {
+			return nil, stageError(StageTree, errors.New("GitHub returned no tree identity"))
+		}
+
+		commit, err := client.createCommit(ctx, forkOwner, forkName, title, tree.SHA, baseReference.Object.SHA)
+		if err != nil {
+			return nil, stageError(StageCommit, err)
+		}
+
+		if commit.SHA == "" {
+			return nil, stageError(StageCommit, errors.New("GitHub returned no commit identity"))
+		}
+
+		if err := client.createReference(ctx, forkOwner, forkName, branch, commit.SHA); err != nil {
+			if !hasStatus(err, http.StatusUnprocessableEntity) {
+				return nil, stageError(StageBranch, err)
+			}
+
+			reused, checkErr := s.existingBranch(ctx, client, forkOwner, forkName, branch, baseReference.Object.SHA, pending)
+			if checkErr != nil || !reused {
+				if checkErr != nil {
+					err = errors.Join(err, checkErr)
+				}
+
+				return nil, stageError(StageBranch, err)
+			}
+		}
+	}
+
+	body := fmt.Sprintf(
+		"Publish `%s/%s@%s`.\n\n- Source: %s\n- Tag: `%s`\n- Commit: `%s`\n\nGenerated by `ferret mod publish`.\n",
+		publication.Module.Owner,
+		publication.Module.Name,
+		publication.Version.Version,
+		publication.Module.Source.Repository,
+		publication.Version.Tag,
+		publication.Version.Commit,
+	)
+	pull, err := client.createPullRequest(
+		ctx,
+		upstreamOwner,
+		upstreamName,
+		title,
+		body,
+		currentUser.Login+":"+branch,
+		upstream.DefaultBranch,
+	)
+	if err != nil {
+		if hasStatus(err, http.StatusUnprocessableEntity) {
+			existing, findErr := s.findPullRequest(ctx, client, upstream.DefaultBranch, pending, versionPath)
+			if findErr == nil && existing != nil {
+				return &modulepublish.Submission{URL: existing.HTMLURL, Existing: true}, nil
+			}
+
+			if findErr != nil {
+				err = errors.Join(err, findErr)
+			}
+		}
+
+		return nil, stageError(StagePullRequest, err)
+	}
+
+	if pull.HTMLURL == "" {
+		return nil, stageError(StagePullRequest, errors.New("GitHub returned no pull request URL"))
+	}
+
+	return &modulepublish.Submission{URL: pull.HTMLURL}, nil
+}
+
+func (s *Submitter) reconcile(ctx context.Context, client *client, base string, records []record) ([]record, error) {
+	pending := make([]record, 0, len(records))
+
+	for _, item := range records {
+		content, err := client.content(ctx, upstreamOwner, upstreamName, item.Path, base)
+		if err != nil {
+			if hasStatus(err, http.StatusNotFound) {
+				pending = append(pending, item)
+
+				continue
+			}
+
+			return nil, fmt.Errorf("read upstream record %s: %w", item.Path, err)
+		}
+
+		if !bytes.Equal(content, item.Content) {
+			return nil, fmt.Errorf("%w: %s", ErrImmutableConflict, item.Path)
+		}
+	}
+
+	return pending, nil
+}
+
+func (s *Submitter) findPullRequest(ctx context.Context, client *client, base string, records []record, versionPath string) (*pullRequest, error) {
+	pulls, err := client.pullRequests(ctx, upstreamOwner, upstreamName, base)
+
+	if err != nil {
+		return nil, fmt.Errorf("list open Barn pull requests: %w", err)
+	}
+
+	for index := range pulls {
+		pull := &pulls[index]
+		files, err := client.pullFiles(ctx, upstreamOwner, upstreamName, pull.Number)
+		if err != nil {
+			return nil, fmt.Errorf("list files for %s: %w", pull.HTMLURL, err)
+		}
+
+		containsVersion := false
+		for _, file := range files {
+			if file.Filename == versionPath {
+				containsVersion = true
+
+				break
+			}
+		}
+
+		if !containsVersion {
+			continue
+		}
+
+		if !sameRecordSet(files, records) || pull.Head.Repo == nil {
+			return nil, fmt.Errorf("%w: %s", ErrPullConflict, pull.HTMLURL)
+		}
+
+		headOwner, headName, valid := splitRepository(pull.Head.Repo.FullName)
+		if !valid {
+			return nil, fmt.Errorf("pull request %s has invalid head repository %q", pull.HTMLURL, pull.Head.Repo.FullName)
+		}
+
+		for _, item := range records {
+			content, err := client.content(ctx, headOwner, headName, item.Path, pull.Head.SHA)
+			if err != nil || !bytes.Equal(content, item.Content) {
+				return nil, fmt.Errorf("%w: %s", ErrPullConflict, pull.HTMLURL)
+			}
+		}
+
+		return pull, nil
+	}
+
+	return nil, nil
+}
+
+func (s *Submitter) fork(ctx context.Context, client *client, login string) (*repository, error) {
+	forks, err := client.forks(ctx, upstreamOwner, upstreamName)
+	if err != nil {
+		return nil, fmt.Errorf("list Barn forks: %w", err)
+	}
+
+	for index := range forks {
+		if strings.EqualFold(forks[index].Owner.Login, login) {
+			return s.waitForFork(ctx, client, forks[index].FullName)
+		}
+	}
+
+	created, err := client.createFork(ctx, upstreamOwner, upstreamName)
+	if err != nil {
+		return nil, fmt.Errorf("create personal Barn fork: %w", err)
+	}
+
+	return s.waitForFork(ctx, client, created.FullName)
+}
+
+func (s *Submitter) waitForFork(ctx context.Context, client *client, fullName string) (*repository, error) {
+	owner, name, valid := splitRepository(fullName)
+	if !valid {
+		return nil, fmt.Errorf("GitHub returned invalid fork identity %q", fullName)
+	}
+
+	waitContext, cancel := context.WithTimeout(ctx, forkTimeout)
+	defer cancel()
+
+	for {
+		fork, err := client.repository(waitContext, owner, name)
+		if err == nil {
+			if !fork.Permissions.Push {
+				return nil, fmt.Errorf("authenticated user cannot write to personal fork %s", fullName)
+			}
+
+			return fork, nil
+		}
+
+		if !hasStatus(err, http.StatusNotFound) {
+			return nil, fmt.Errorf("load personal fork %s: %w", fullName, err)
+		}
+
+		timer := time.NewTimer(s.pollInterval)
+		select {
+		case <-waitContext.Done():
+			timer.Stop()
+
+			return nil, fmt.Errorf("wait for personal fork %s: %w", fullName, waitContext.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *Submitter) existingBranch(ctx context.Context, client *client, owner, name, branch, base string, records []record) (bool, error) {
+	reference, err := client.reference(ctx, owner, name, branch)
+	if err != nil {
+		if hasStatus(err, http.StatusNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("read publication branch %q: %w", branch, err)
+	}
+
+	details, err := client.commitDetails(ctx, owner, name, reference.Object.SHA)
+	if err != nil {
+		return false, fmt.Errorf("inspect publication branch %q: %w", branch, err)
+	}
+
+	if len(details.Parents) != 1 || details.Parents[0].SHA != base || !sameRecordSet(details.Files, records) {
+		return false, fmt.Errorf("%w: %s; delete the branch from %s/%s and retry", ErrBranchConflict, branch, owner, name)
+	}
+
+	for _, item := range records {
+		content, err := client.content(ctx, owner, name, item.Path, reference.Object.SHA)
+		if err != nil || !bytes.Equal(content, item.Content) {
+			return false, fmt.Errorf("%w: %s; delete the branch from %s/%s and retry", ErrBranchConflict, branch, owner, name)
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/module/publish/github/submitter_test.go
+++ b/pkg/module/publish/github/submitter_test.go
@@ -1,0 +1,462 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+)
+
+func TestSubmitterCreatesFocusedForkPullRequest(t *testing.T) {
+	publication := testPublication(barnpublish.NewModule)
+	expectedRecords := make(map[string]string, len(publication.Files))
+	for _, file := range publication.Files {
+		expectedRecords[file.Path] = string(file.Content)
+	}
+	mutations := make([]string, 0, 4)
+	treePaths := make([]string, 0, 2)
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case request.Method == http.MethodGet && path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case request.Method == http.MethodGet && path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "MontFerret/barn", DefaultBranch: "main"}), nil
+		case request.Method == http.MethodGet && strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base-sha"}}), nil
+		case request.Method == http.MethodGet && path == "/repos/MontFerret/barn/git/commits/base-sha":
+			return jsonResponse(http.StatusOK, gitCommit{SHA: "base-sha", Tree: gitObject{SHA: "base-tree"}}), nil
+		case request.Method == http.MethodGet && strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case request.Method == http.MethodGet && path == "/repos/MontFerret/barn/pulls":
+			return jsonResponse(http.StatusOK, []pullRequest{}), nil
+		case request.Method == http.MethodGet && path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusOK, []repository{}), nil
+		case request.Method == http.MethodPost && path == "/repos/MontFerret/barn/forks":
+			mutations = append(mutations, "fork")
+
+			return jsonResponse(http.StatusAccepted, repository{FullName: "alice/renamed-barn", Owner: user{Login: "alice"}}), nil
+		case request.Method == http.MethodGet && path == "/repos/alice/renamed-barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "alice/renamed-barn", Permissions: permissions{Push: true}}), nil
+		case request.Method == http.MethodGet && strings.HasPrefix(path, "/repos/alice/renamed-barn/git/ref/heads/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case request.Method == http.MethodPost && path == "/repos/alice/renamed-barn/git/trees":
+			mutations = append(mutations, "tree")
+			var body struct {
+				BaseTree string `json:"base_tree"`
+				Tree     []struct {
+					Path    string `json:"path"`
+					Content string `json:"content"`
+				} `json:"tree"`
+			}
+			readJSONBody(t, request, &body)
+			if body.BaseTree != "base-tree" || len(body.Tree) != 2 {
+				t.Fatalf("unexpected tree request: %#v", body)
+			}
+			for _, entry := range body.Tree {
+				treePaths = append(treePaths, entry.Path)
+				if strings.HasPrefix(entry.Path, "dist/") || strings.Contains(entry.Content, "publishedAt") {
+					t.Fatalf("unsafe tree entry: %#v", entry)
+				}
+				if expectedRecords[entry.Path] != entry.Content {
+					t.Fatalf("tree entry did not preserve prepared bytes: %#v", entry)
+				}
+			}
+
+			return jsonResponse(http.StatusCreated, createdTree{SHA: "new-tree"}), nil
+		case request.Method == http.MethodPost && path == "/repos/alice/renamed-barn/git/commits":
+			mutations = append(mutations, "commit")
+			var body struct {
+				Message string   `json:"message"`
+				Tree    string   `json:"tree"`
+				Parents []string `json:"parents"`
+			}
+			readJSONBody(t, request, &body)
+			if body.Message != "Publish acme/widget@1.2.3" || body.Tree != "new-tree" || len(body.Parents) != 1 || body.Parents[0] != "base-sha" {
+				t.Fatalf("unexpected commit request: %#v", body)
+			}
+
+			return jsonResponse(http.StatusCreated, createdCommit{SHA: "new-commit"}), nil
+		case request.Method == http.MethodPost && path == "/repos/alice/renamed-barn/git/refs":
+			mutations = append(mutations, "reference")
+
+			return jsonResponse(http.StatusCreated, gitReference{}), nil
+		case request.Method == http.MethodPost && path == "/repos/MontFerret/barn/pulls":
+			mutations = append(mutations, "pull")
+			var body map[string]any
+			readJSONBody(t, request, &body)
+			pullBody, _ := body["body"].(string)
+			if body["title"] != "Publish acme/widget@1.2.3" ||
+				body["head"] != "alice:ferret-publish/acme-widget-v1.2.3-abcdef01" ||
+				body["base"] != "main" ||
+				!strings.Contains(pullBody, "https://github.com/acme/widget") ||
+				!strings.Contains(pullBody, "`modules/widget/v1.2.3`") ||
+				!strings.Contains(pullBody, "`abcdef0123456789abcdef0123456789abcdef01`") {
+				t.Fatalf("unexpected pull request body: %#v", body)
+			}
+
+			return jsonResponse(http.StatusCreated, pullRequest{HTMLURL: "https://github.com/MontFerret/barn/pull/123"}), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	token := &fakeTokenProvider{token: "secret"}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(token),
+		WithPollInterval(time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := submitter.Submit(context.Background(), publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.URL != "https://github.com/MontFerret/barn/pull/123" || result.Existing || result.AlreadyPublished {
+		t.Fatalf("unexpected submission result: %#v", result)
+	}
+	if strings.Join(mutations, ",") != "fork,tree,commit,reference,pull" || len(treePaths) != 2 || token.calls != 1 {
+		t.Fatalf("unexpected submission effects: mutations=%v paths=%v tokenCalls=%d", mutations, treePaths, token.calls)
+	}
+}
+
+func TestSubmitterReturnsExistingMatchingPullRequestWithoutMutation(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	versionFile := publication.Files[0]
+	mutations := 0
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		if request.Method != http.MethodGet {
+			mutations++
+		}
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls":
+			return jsonResponse(http.StatusOK, []pullRequest{{
+				Number: 7, HTMLURL: "https://github.com/MontFerret/barn/pull/7",
+				Head: pullHead{SHA: "head", Repo: &repository{FullName: "bob/barn"}},
+			}}), nil
+		case path == "/repos/MontFerret/barn/pulls/7/files":
+			return jsonResponse(http.StatusOK, []pullFile{{Filename: versionFile.Path, Status: "added"}}), nil
+		case strings.Contains(path, "/repos/bob/barn/contents/"):
+			return jsonResponse(http.StatusOK, encodedContent(versionFile.Content)), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := submitter.Submit(context.Background(), publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.URL != "https://github.com/MontFerret/barn/pull/7" || !result.Existing || mutations != 0 {
+		t.Fatalf("unexpected existing submission: result=%#v mutations=%d", result, mutations)
+	}
+}
+
+func TestSubmitterTreatsIdenticalUpstreamRecordsAsPublished(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	versionFile := publication.Files[0]
+	mutations := 0
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet {
+			mutations++
+		}
+		switch {
+		case request.URL.Path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case request.URL.Path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(request.URL.Path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case request.URL.Path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(request.URL.Path, "/repos/MontFerret/barn/contents/"):
+			return jsonResponse(http.StatusOK, encodedContent(versionFile.Content)), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := submitter.Submit(context.Background(), publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.AlreadyPublished || mutations != 0 {
+		t.Fatalf("unexpected published result: result=%#v mutations=%d", result, mutations)
+	}
+}
+
+func TestSubmitterRejectsDivergentRetryBranch(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls":
+			return jsonResponse(http.StatusOK, []pullRequest{}), nil
+		case request.Method == http.MethodGet && path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusOK, []repository{{FullName: "alice/barn", Owner: user{Login: "alice"}}}), nil
+		case path == "/repos/alice/barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "alice/barn", Permissions: permissions{Push: true}}), nil
+		case strings.HasPrefix(path, "/repos/alice/barn/git/ref/heads/"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "branch"}}), nil
+		case path == "/repos/alice/barn/commits/branch":
+			return jsonResponse(http.StatusOK, commitDetails{Parents: []gitObject{{SHA: "old-base"}}}), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.Submit(context.Background(), publication)
+	if !errors.Is(err, ErrBranchConflict) || !strings.Contains(err.Error(), "delete the branch") {
+		t.Fatalf("unexpected branch conflict: %v", err)
+	}
+}
+
+func TestSubmitterReusesExactRetryBranch(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	versionFile := publication.Files[0]
+	mutations := make([]string, 0, 1)
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, []pullRequest{}), nil
+		case path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusOK, []repository{{FullName: "alice/barn", Owner: user{Login: "alice"}}}), nil
+		case path == "/repos/alice/barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "alice/barn", Permissions: permissions{Push: true}}), nil
+		case strings.HasPrefix(path, "/repos/alice/barn/git/ref/heads/"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "branch"}}), nil
+		case path == "/repos/alice/barn/commits/branch":
+			return jsonResponse(http.StatusOK, commitDetails{
+				Parents: []gitObject{{SHA: "base"}},
+				Files:   []pullFile{{Filename: versionFile.Path, Status: "added"}},
+			}), nil
+		case strings.Contains(path, "/repos/alice/barn/contents/"):
+			return jsonResponse(http.StatusOK, encodedContent(versionFile.Content)), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodPost:
+			mutations = append(mutations, "pull")
+
+			return jsonResponse(http.StatusCreated, pullRequest{HTMLURL: "https://github.com/MontFerret/barn/pull/9"}), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := submitter.Submit(context.Background(), publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.URL != "https://github.com/MontFerret/barn/pull/9" || strings.Join(mutations, ",") != "pull" {
+		t.Fatalf("unexpected exact branch retry: result=%#v mutations=%v", result, mutations)
+	}
+}
+
+func TestSubmitterAuthenticationFailureMakesNoGitHubRequest(t *testing.T) {
+	want := errors.New("not authenticated")
+	requests := 0
+	transport := &scriptedTransport{handle: func(*http.Request) (*http.Response, error) {
+		requests++
+
+		return nil, errors.New("unexpected request")
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{err: want}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.Submit(context.Background(), testPublication(barnpublish.NewVersion))
+	var submissionError *Error
+	if !errors.Is(err, want) || !errors.As(err, &submissionError) || submissionError.Stage != StageAuthentication || requests != 0 {
+		t.Fatalf("unexpected authentication result: err=%v requests=%d", err, requests)
+	}
+}
+
+func TestSubmitterRejectsConflictingUpstreamRecordBeforeMutation(t *testing.T) {
+	mutations := 0
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet {
+			mutations++
+		}
+		switch {
+		case request.URL.Path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case request.URL.Path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(request.URL.Path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case request.URL.Path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(request.URL.Path, "/repos/MontFerret/barn/contents/"):
+			return jsonResponse(http.StatusOK, encodedContent([]byte("different\n"))), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.Submit(context.Background(), testPublication(barnpublish.NewVersion))
+	if !errors.Is(err, ErrImmutableConflict) || mutations != 0 {
+		t.Fatalf("unexpected immutable conflict: err=%v mutations=%d", err, mutations)
+	}
+}
+
+func TestSubmitterPreservesOperationFailureStages(t *testing.T) {
+	for _, test := range []struct {
+		failure string
+		stage   Stage
+	}{
+		{failure: "fork", stage: StageFork},
+		{failure: "tree", stage: StageTree},
+		{failure: "commit", stage: StageCommit},
+		{failure: "reference", stage: StageBranch},
+		{failure: "pull", stage: StagePullRequest},
+	} {
+		t.Run(test.failure, func(t *testing.T) {
+			submitter, err := New(
+				WithHTTPClient(&http.Client{Transport: submissionFailureTransport(t, test.failure)}),
+				WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = submitter.Submit(context.Background(), testPublication(barnpublish.NewVersion))
+			var submissionError *Error
+			if !errors.As(err, &submissionError) || submissionError.Stage != test.stage {
+				t.Fatalf("unexpected failure stage: %v", err)
+			}
+		})
+	}
+}
+
+func TestSubmitterStopsWaitingForForkWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls":
+			return jsonResponse(http.StatusOK, []pullRequest{}), nil
+		case request.Method == http.MethodGet && path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusOK, []repository{}), nil
+		case request.Method == http.MethodPost && path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusAccepted, repository{FullName: "alice/barn"}), nil
+		case path == "/repos/alice/barn":
+			cancel()
+
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+		WithPollInterval(time.Hour),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.Submit(ctx, testPublication(barnpublish.NewVersion))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+}

--- a/pkg/module/publish/github/submitter_test.go
+++ b/pkg/module/publish/github/submitter_test.go
@@ -326,6 +326,129 @@ func TestSubmitterReusesExactRetryBranch(t *testing.T) {
 	}
 }
 
+func TestSubmitterRecoversReferenceCreationRace(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	versionFile := publication.Files[0]
+	branchLookups := 0
+	mutations := make([]string, 0, 4)
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		path := request.URL.Path
+		switch {
+		case path == "/user":
+			return jsonResponse(http.StatusOK, user{Login: "alice"}), nil
+		case path == "/repos/MontFerret/barn":
+			return jsonResponse(http.StatusOK, repository{DefaultBranch: "main"}), nil
+		case strings.HasPrefix(path, "/repos/MontFerret/barn/git/ref/heads/main"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "base"}}), nil
+		case path == "/repos/MontFerret/barn/git/commits/base":
+			return jsonResponse(http.StatusOK, gitCommit{Tree: gitObject{SHA: "tree"}}), nil
+		case strings.Contains(path, "/repos/MontFerret/barn/contents/"):
+			return apiFailure(http.StatusNotFound, "Not Found"), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodGet:
+			return jsonResponse(http.StatusOK, []pullRequest{}), nil
+		case path == "/repos/MontFerret/barn/forks":
+			return jsonResponse(http.StatusOK, []repository{{FullName: "alice/barn", Owner: user{Login: "alice"}}}), nil
+		case path == "/repos/alice/barn":
+			return jsonResponse(http.StatusOK, repository{FullName: "alice/barn", Permissions: permissions{Push: true}}), nil
+		case request.Method == http.MethodGet && strings.HasPrefix(path, "/repos/alice/barn/git/ref/heads/"):
+			branchLookups++
+			if branchLookups == 1 {
+				return apiFailure(http.StatusNotFound, "Not Found"), nil
+			}
+
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "new-commit"}}), nil
+		case path == "/repos/alice/barn/git/trees":
+			mutations = append(mutations, "tree")
+
+			return jsonResponse(http.StatusCreated, createdTree{SHA: "new-tree"}), nil
+		case path == "/repos/alice/barn/git/commits":
+			mutations = append(mutations, "commit")
+
+			return jsonResponse(http.StatusCreated, createdCommit{SHA: "new-commit"}), nil
+		case path == "/repos/alice/barn/git/refs":
+			mutations = append(mutations, "reference")
+
+			return apiFailure(http.StatusUnprocessableEntity, "Reference already exists"), nil
+		case path == "/repos/alice/barn/commits/new-commit":
+			return jsonResponse(http.StatusOK, commitDetails{
+				Parents: []gitObject{{SHA: "base"}},
+				Files:   []pullFile{{Filename: versionFile.Path, Status: "added"}},
+			}), nil
+		case strings.Contains(path, "/repos/alice/barn/contents/"):
+			return jsonResponse(http.StatusOK, encodedContent(versionFile.Content)), nil
+		case path == "/repos/MontFerret/barn/pulls" && request.Method == http.MethodPost:
+			mutations = append(mutations, "pull")
+
+			return jsonResponse(http.StatusCreated, pullRequest{HTMLURL: "https://github.com/MontFerret/barn/pull/10"}), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(
+		WithHTTPClient(&http.Client{Transport: transport}),
+		WithTokenProvider(&fakeTokenProvider{token: "secret"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := submitter.Submit(context.Background(), publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.URL != "https://github.com/MontFerret/barn/pull/10" || result.Existing || branchLookups != 2 ||
+		strings.Join(mutations, ",") != "tree,commit,reference,pull" {
+		t.Fatalf("unexpected reference race recovery: result=%#v lookups=%d mutations=%v", result, branchLookups, mutations)
+	}
+}
+
+func TestSubmitterPreservesBranchContentReadFailure(t *testing.T) {
+	publication := testPublication(barnpublish.NewVersion)
+	records, _, err := publicationRecords(publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branch := "ferret-publish/acme-widget-v1.2.3-abcdef01"
+	transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasPrefix(request.URL.Path, "/repos/alice/barn/git/ref/heads/"):
+			return jsonResponse(http.StatusOK, gitReference{Object: gitObject{SHA: "branch"}}), nil
+		case request.URL.Path == "/repos/alice/barn/commits/branch":
+			return jsonResponse(http.StatusOK, commitDetails{
+				Parents: []gitObject{{SHA: "base"}},
+				Files:   []pullFile{{Filename: records[0].Path, Status: "added"}},
+			}), nil
+		case strings.Contains(request.URL.Path, "/repos/alice/barn/contents/"):
+			return apiFailure(http.StatusInternalServerError, "content unavailable"), nil
+		default:
+			t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+
+			return nil, nil
+		}
+	}}
+	submitter, err := New(WithHTTPClient(&http.Client{Transport: transport}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = submitter.existingBranch(
+		context.Background(),
+		newClient("https://api.github.test", &http.Client{Transport: transport}, "secret"),
+		"alice",
+		"barn",
+		branch,
+		"base",
+		records,
+	)
+	if err == nil || errors.Is(err, ErrBranchConflict) || strings.Contains(err.Error(), "delete the branch") ||
+		!strings.Contains(err.Error(), "read publication branch record "+records[0].Path) ||
+		!strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("unexpected branch content failure: %v", err)
+	}
+}
+
 func TestSubmitterAuthenticationFailureMakesNoGitHubRequest(t *testing.T) {
 	want := errors.New("not authenticated")
 	requests := 0
@@ -344,8 +467,46 @@ func TestSubmitterAuthenticationFailureMakesNoGitHubRequest(t *testing.T) {
 
 	_, err = submitter.Submit(context.Background(), testPublication(barnpublish.NewVersion))
 	var submissionError *Error
-	if !errors.Is(err, want) || !errors.As(err, &submissionError) || submissionError.Stage != StageAuthentication || requests != 0 {
+	if !errors.Is(err, want) || !errors.As(err, &submissionError) || submissionError.Stage != StageAuthentication || requests != 0 ||
+		!strings.Contains(err.Error(), "GH_TOKEN") || !strings.Contains(err.Error(), "gh auth login") {
 		t.Fatalf("unexpected authentication result: err=%v requests=%d", err, requests)
+	}
+}
+
+func TestSubmitterReturnsActionableCredentialValidationErrors(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		response *http.Response
+	}{
+		{name: "invalid token", response: apiFailure(http.StatusUnauthorized, "Bad credentials")},
+		{name: "empty user", response: jsonResponse(http.StatusOK, user{})},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			transport := &scriptedTransport{handle: func(request *http.Request) (*http.Response, error) {
+				requests++
+				if request.URL.Path != "/user" {
+					t.Fatalf("unexpected GitHub request: %s %s", request.Method, request.URL)
+				}
+
+				return test.response, nil
+			}}
+			submitter, err := New(
+				WithHTTPClient(&http.Client{Transport: transport}),
+				WithTokenProvider(&fakeTokenProvider{token: "secret-token-value"}),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = submitter.Submit(context.Background(), testPublication(barnpublish.NewVersion))
+			var submissionError *Error
+			if err == nil || !errors.As(err, &submissionError) || submissionError.Stage != StageAuthentication || requests != 1 ||
+				!strings.Contains(err.Error(), "GH_TOKEN") || !strings.Contains(err.Error(), "gh auth login") ||
+				strings.Contains(err.Error(), "secret-token-value") {
+				t.Fatalf("unexpected credential validation error: %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/module/publish/github/token_source.go
+++ b/pkg/module/publish/github/token_source.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type (
+	// TokenProvider supplies a GitHub access token without exposing it to output.
+	TokenProvider interface {
+		Token(context.Context) (string, error)
+	}
+
+	commandRunner interface {
+		Run(context.Context, string, ...string) ([]byte, error)
+	}
+
+	// TokenSource resolves GitHub credentials from the environment or GitHub CLI.
+	TokenSource struct {
+		getenv func(string) string
+		run    commandRunner
+	}
+)
+
+// NewTokenSource constructs the default non-interactive credential resolver.
+func NewTokenSource() *TokenSource {
+	return &TokenSource{
+		getenv: os.Getenv,
+		run: commandRunnerFunc(func(ctx context.Context, name string, arguments ...string) ([]byte, error) {
+			return exec.CommandContext(ctx, name, arguments...).Output()
+		}),
+	}
+}
+
+// Token resolves GH_TOKEN, GITHUB_TOKEN, or the current gh CLI credential.
+func (s *TokenSource) Token(ctx context.Context) (string, error) {
+	for _, name := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if token := strings.TrimSpace(s.getenv(name)); token != "" {
+			return token, nil
+		}
+	}
+
+	data, err := s.run.Run(ctx, "gh", "auth", "token", "--hostname", "github.com")
+	if err == nil {
+		if token := strings.TrimSpace(string(data)); token != "" {
+			return token, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"GitHub authentication is required; set GH_TOKEN or GITHUB_TOKEN, or run %q",
+		"gh auth login --hostname github.com",
+	)
+}

--- a/pkg/module/publish/github/token_source.go
+++ b/pkg/module/publish/github/token_source.go
@@ -44,14 +44,17 @@ func (s *TokenSource) Token(ctx context.Context) (string, error) {
 	}
 
 	data, err := s.run.Run(ctx, "gh", "auth", "token", "--hostname", "github.com")
+	if contextErr := ctx.Err(); contextErr != nil {
+		return "", contextErr
+	}
+
 	if err == nil {
 		if token := strings.TrimSpace(string(data)); token != "" {
 			return token, nil
 		}
+
+		err = fmt.Errorf("GitHub CLI returned no credential")
 	}
 
-	return "", fmt.Errorf(
-		"GitHub authentication is required; set GH_TOKEN or GITHUB_TOKEN, or run %q",
-		"gh auth login --hostname github.com",
-	)
+	return "", newAuthenticationError(fmt.Errorf("resolve GitHub credential: %w", err))
 }

--- a/pkg/module/publish/github/token_source_test.go
+++ b/pkg/module/publish/github/token_source_test.go
@@ -1,0 +1,58 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTokenSourceUsesEnvironmentPrecedence(t *testing.T) {
+	source := &TokenSource{
+		getenv: func(name string) string {
+			return map[string]string{"GH_TOKEN": " gh-token ", "GITHUB_TOKEN": "github-token"}[name]
+		},
+		run: commandRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			t.Fatal("GitHub CLI ran despite an environment token")
+
+			return nil, nil
+		}),
+	}
+
+	token, err := source.Token(context.Background())
+	if err != nil || token != "gh-token" {
+		t.Fatalf("unexpected token resolution: token=%q err=%v", token, err)
+	}
+}
+
+func TestTokenSourceFallsBackToGitHubCLI(t *testing.T) {
+	var command string
+	var arguments []string
+	source := &TokenSource{
+		getenv: func(string) string { return "" },
+		run: commandRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			command, arguments = name, args
+
+			return []byte("cli-token\n"), nil
+		}),
+	}
+
+	token, err := source.Token(context.Background())
+	if err != nil || token != "cli-token" || command != "gh" || strings.Join(arguments, " ") != "auth token --hostname github.com" {
+		t.Fatalf("unexpected CLI token resolution: token=%q command=%q args=%q err=%v", token, command, arguments, err)
+	}
+}
+
+func TestTokenSourceReturnsActionableAuthenticationError(t *testing.T) {
+	source := &TokenSource{
+		getenv: func(string) string { return "" },
+		run: commandRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			return nil, errors.New("gh is unavailable")
+		}),
+	}
+
+	_, err := source.Token(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "GH_TOKEN") || !strings.Contains(err.Error(), "gh auth login") {
+		t.Fatalf("unexpected authentication error: %v", err)
+	}
+}

--- a/pkg/module/publish/github/token_source_test.go
+++ b/pkg/module/publish/github/token_source_test.go
@@ -56,3 +56,20 @@ func TestTokenSourceReturnsActionableAuthenticationError(t *testing.T) {
 		t.Fatalf("unexpected authentication error: %v", err)
 	}
 }
+
+func TestTokenSourcePreservesGitHubCLICancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	source := &TokenSource{
+		getenv: func(string) string { return "" },
+		run: commandRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			cancel()
+
+			return nil, errors.New("command interrupted")
+		}),
+	}
+
+	_, err := source.Token(ctx)
+	if !errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "gh auth login") {
+		t.Fatalf("expected unmodified context cancellation, got %v", err)
+	}
+}

--- a/pkg/module/publish/github/types.go
+++ b/pkg/module/publish/github/types.go
@@ -1,0 +1,71 @@
+package github
+
+type (
+	user struct {
+		Login string `json:"login"`
+	}
+
+	repository struct {
+		Name          string      `json:"name"`
+		FullName      string      `json:"full_name"`
+		DefaultBranch string      `json:"default_branch"`
+		Owner         user        `json:"owner"`
+		Parent        *repository `json:"parent,omitempty"`
+		Permissions   permissions `json:"permissions"`
+	}
+
+	permissions struct {
+		Push bool `json:"push"`
+	}
+
+	gitReference struct {
+		Ref    string    `json:"ref"`
+		Object gitObject `json:"object"`
+	}
+
+	gitObject struct {
+		SHA string `json:"sha"`
+	}
+
+	gitCommit struct {
+		SHA     string      `json:"sha"`
+		Tree    gitObject   `json:"tree"`
+		Parents []gitObject `json:"parents"`
+	}
+
+	commitDetails struct {
+		SHA     string      `json:"sha"`
+		Parents []gitObject `json:"parents"`
+		Files   []pullFile  `json:"files"`
+	}
+
+	pullRequest struct {
+		Number  int      `json:"number"`
+		HTMLURL string   `json:"html_url"`
+		Head    pullHead `json:"head"`
+	}
+
+	pullHead struct {
+		Ref  string      `json:"ref"`
+		SHA  string      `json:"sha"`
+		Repo *repository `json:"repo"`
+	}
+
+	pullFile struct {
+		Filename string `json:"filename"`
+		Status   string `json:"status"`
+	}
+
+	contentResponse struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+
+	createdTree struct {
+		SHA string `json:"sha"`
+	}
+
+	createdCommit struct {
+		SHA string `json:"sha"`
+	}
+)

--- a/pkg/module/publish/helpers.go
+++ b/pkg/module/publish/helpers.go
@@ -1,0 +1,17 @@
+package publish
+
+import (
+	"path"
+
+	modulemanifest "github.com/MontFerret/specs/pkg/module"
+)
+
+func defaultTag(manifest *modulemanifest.Manifest) string {
+	tag := "v" + manifest.Version
+
+	if manifest.Repository != nil && manifest.Repository.Directory != "" {
+		tag = path.Join(manifest.Repository.Directory, tag)
+	}
+
+	return tag
+}

--- a/pkg/module/publish/publisher.go
+++ b/pkg/module/publish/publisher.go
@@ -2,7 +2,8 @@ package publish
 
 import (
 	"context"
-	"path"
+	"errors"
+	"fmt"
 	"path/filepath"
 
 	barnpublish "github.com/MontFerret/barn/pkg/publish"
@@ -12,13 +13,20 @@ import (
 
 // Publisher adapts the CLI's publication options to Barn's public API.
 type Publisher struct {
-	registry *barnregistry.Client
-	prepare  func(context.Context, barnpublish.Request) (*barnpublish.Result, error)
+	registry  *barnregistry.Client
+	prepare   func(context.Context, barnpublish.Request) (*barnpublish.Result, error)
+	submitter Submitter
 }
 
-// New constructs a publication preparer.
-func New(registry *barnregistry.Client) *Publisher {
-	return &Publisher{registry: registry, prepare: barnpublish.Prepare}
+// New constructs a publication workflow.
+func New(registry *barnregistry.Client, submitters ...Submitter) *Publisher {
+	var submitter Submitter
+
+	if len(submitters) > 0 {
+		submitter = submitters[0]
+	}
+
+	return &Publisher{registry: registry, prepare: barnpublish.Prepare, submitter: submitter}
 }
 
 // Prepare derives the CLI's optional default tag and delegates validation to Barn.
@@ -35,11 +43,102 @@ func (p *Publisher) Prepare(ctx context.Context, options Options) (*barnpublish.
 			return nil, err
 		}
 
-		tag = "v" + manifest.Version
-		if manifest.Repository != nil && manifest.Repository.Directory != "" {
-			tag = path.Join(manifest.Repository.Directory, tag)
-		}
+		tag = defaultTag(manifest)
 	}
 
 	return p.prepare(ctx, barnpublish.Request{Directory: directory, Tag: tag, Registry: p.registry})
+}
+
+// Publish prepares a release and submits it unless a non-mutating mode is selected.
+// When submission fails, the returned result retains the successfully prepared records.
+func (p *Publisher) Publish(ctx context.Context, options Options) (*Result, error) {
+	mode := options.Mode
+	if mode == "" {
+		mode = ModeSubmit
+	}
+
+	if mode != ModeSubmit && mode != ModeDryRun && mode != ModePrint {
+		return nil, fmt.Errorf("unsupported publication mode %q", mode)
+	}
+
+	request, manifest, err := p.request(options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		Status:  StatusReady,
+		Module:  manifest.Name,
+		Version: manifest.Version,
+		Tag:     request.Tag,
+	}
+
+	prepared, err := p.prepare(ctx, request)
+	if err != nil {
+		if errors.Is(err, barnpublish.ErrVersionAlreadyPublished) {
+			result.Status = StatusAlreadyPublished
+
+			return result, nil
+		}
+
+		return nil, err
+	}
+
+	result.Prepared = prepared
+
+	if mode != ModeSubmit {
+		return result, nil
+	}
+
+	if p.submitter == nil {
+		return result, errors.New("GitHub Registry submission is not configured")
+	}
+
+	submission, err := p.submitter.Submit(ctx, prepared)
+	if err != nil {
+		return result, err
+	}
+
+	if submission == nil {
+		return result, errors.New("GitHub Registry submission returned no result")
+	}
+
+	if submission.AlreadyPublished {
+		result.Status = StatusAlreadyPublished
+
+		return result, nil
+	}
+
+	if submission.URL == "" {
+		return result, errors.New("GitHub Registry submission returned no pull request URL")
+	}
+
+	result.PullRequestURL = submission.URL
+
+	if submission.Existing {
+		result.Status = StatusExistingSubmission
+	} else {
+		result.Status = StatusSubmitted
+	}
+
+	return result, nil
+}
+
+func (p *Publisher) request(options Options) (barnpublish.Request, *modulemanifest.Manifest, error) {
+	directory := options.Directory
+	if directory == "" {
+		directory = "."
+	}
+
+	manifest, err := modulemanifest.LoadFile(filepath.Join(directory, modulemanifest.ManifestFilename))
+	if err != nil {
+		return barnpublish.Request{}, nil, err
+	}
+
+	tag := options.Tag
+	if tag == "" {
+		tag = defaultTag(manifest)
+	}
+
+	return barnpublish.Request{Directory: directory, Tag: tag, Registry: p.registry}, manifest, nil
 }

--- a/pkg/module/publish/publisher_test.go
+++ b/pkg/module/publish/publisher_test.go
@@ -3,6 +3,7 @@ package publish
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,6 +87,88 @@ func TestPublisherValidatesManifestBeforeDerivingTag(t *testing.T) {
 	}
 	if called {
 		t.Fatal("Barn publication ran after default-tag derivation failed")
+	}
+}
+
+func TestPublisherPublishesPreparedRecords(t *testing.T) {
+	directory := t.TempDir()
+	writePublisherManifest(t, directory, "")
+	wantPrepared := &barnpublish.Result{Kind: barnpublish.NewModule}
+	submitter := &fakeSubmitter{submission: &Submission{URL: "https://github.com/MontFerret/barn/pull/123"}}
+	publisher := New(nil, submitter)
+	publisher.prepare = func(context.Context, barnpublish.Request) (*barnpublish.Result, error) {
+		return wantPrepared, nil
+	}
+
+	result, err := publisher.Publish(context.Background(), Options{Directory: directory})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StatusSubmitted || result.Prepared != wantPrepared || result.PullRequestURL != submitter.submission.URL {
+		t.Fatalf("unexpected publication result: %#v", result)
+	}
+	if submitter.calls != 1 || submitter.prepared != wantPrepared {
+		t.Fatalf("unexpected submitter call: calls=%d prepared=%#v", submitter.calls, submitter.prepared)
+	}
+}
+
+func TestPublisherNonMutatingModesNeverSubmit(t *testing.T) {
+	for _, mode := range []Mode{ModeDryRun, ModePrint} {
+		t.Run(string(mode), func(t *testing.T) {
+			directory := t.TempDir()
+			writePublisherManifest(t, directory, "modules/widget")
+			submitter := new(fakeSubmitter)
+			publisher := New(nil, submitter)
+			publisher.prepare = func(context.Context, barnpublish.Request) (*barnpublish.Result, error) {
+				return &barnpublish.Result{Kind: barnpublish.NewVersion}, nil
+			}
+
+			result, err := publisher.Publish(context.Background(), Options{Directory: directory, Mode: mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Status != StatusReady || result.Tag != "modules/widget/v1.2.3" || submitter.calls != 0 {
+				t.Fatalf("unexpected non-mutating result: result=%#v calls=%d", result, submitter.calls)
+			}
+		})
+	}
+}
+
+func TestPublisherAlreadyPublishedIsSuccessfulNoOp(t *testing.T) {
+	for _, mode := range []Mode{ModeSubmit, ModeDryRun, ModePrint} {
+		t.Run(string(mode), func(t *testing.T) {
+			directory := t.TempDir()
+			writePublisherManifest(t, directory, "")
+			submitter := new(fakeSubmitter)
+			publisher := New(nil, submitter)
+			publisher.prepare = func(context.Context, barnpublish.Request) (*barnpublish.Result, error) {
+				return nil, fmt.Errorf("registry state: %w", barnpublish.ErrVersionAlreadyPublished)
+			}
+
+			result, err := publisher.Publish(context.Background(), Options{Directory: directory, Mode: mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Status != StatusAlreadyPublished || result.Module != "acme/widget" || result.Version != "1.2.3" || submitter.calls != 0 {
+				t.Fatalf("unexpected already-published result: result=%#v calls=%d", result, submitter.calls)
+			}
+		})
+	}
+}
+
+func TestPublisherReturnsPreparationAfterSubmissionFailure(t *testing.T) {
+	directory := t.TempDir()
+	writePublisherManifest(t, directory, "")
+	wantErr := errors.New("create pull request")
+	prepared := &barnpublish.Result{Kind: barnpublish.NewModule}
+	publisher := New(nil, &fakeSubmitter{err: wantErr})
+	publisher.prepare = func(context.Context, barnpublish.Request) (*barnpublish.Result, error) {
+		return prepared, nil
+	}
+
+	result, err := publisher.Publish(context.Background(), Options{Directory: directory})
+	if !errors.Is(err, wantErr) || result == nil || result.Status != StatusReady || result.Prepared != prepared {
+		t.Fatalf("unexpected partial result: result=%#v err=%v", result, err)
 	}
 }
 

--- a/pkg/module/publish/publisher_test.go
+++ b/pkg/module/publish/publisher_test.go
@@ -172,6 +172,22 @@ func TestPublisherReturnsPreparationAfterSubmissionFailure(t *testing.T) {
 	}
 }
 
+func TestPublisherPreparationFailureNeverSubmits(t *testing.T) {
+	directory := t.TempDir()
+	writePublisherManifest(t, directory, "")
+	wantErr := errors.New("prepare publication")
+	submitter := new(fakeSubmitter)
+	publisher := New(nil, submitter)
+	publisher.prepare = func(context.Context, barnpublish.Request) (*barnpublish.Result, error) {
+		return nil, wantErr
+	}
+
+	result, err := publisher.Publish(context.Background(), Options{Directory: directory})
+	if !errors.Is(err, wantErr) || result != nil || submitter.calls != 0 {
+		t.Fatalf("unexpected preparation failure: result=%#v err=%v submitterCalls=%d", result, err, submitter.calls)
+	}
+}
+
 func writePublisherManifest(t *testing.T, directory, sourcePath string) {
 	t.Helper()
 

--- a/pkg/module/publish/types.go
+++ b/pkg/module/publish/types.go
@@ -1,7 +1,64 @@
 package publish
 
-// Options controls local publication preparation.
-type Options struct {
-	Directory string
-	Tag       string
-}
+import (
+	"context"
+
+	barnpublish "github.com/MontFerret/barn/pkg/publish"
+)
+
+type (
+	// Mode selects whether a prepared publication is submitted or only inspected.
+	Mode string
+
+	// Status describes the outcome of a publication workflow.
+	Status string
+
+	// Options controls module publication.
+	Options struct {
+		Directory string
+		Tag       string
+		Mode      Mode
+	}
+
+	// Result contains the prepared records and any resulting Registry pull request.
+	Result struct {
+		Status         Status
+		Module         string
+		Version        string
+		Tag            string
+		Prepared       *barnpublish.Result
+		PullRequestURL string
+	}
+
+	// Submission is the provider-independent result of submitting prepared records.
+	Submission struct {
+		URL              string
+		Existing         bool
+		AlreadyPublished bool
+	}
+
+	// Submitter sends prepared Barn records to the Registry governance workflow.
+	Submitter interface {
+		Submit(context.Context, *barnpublish.Result) (*Submission, error)
+	}
+)
+
+const (
+	// ModeSubmit prepares and submits the release to the Registry.
+	ModeSubmit Mode = "submit"
+	// ModeDryRun prepares the release without provider authentication or mutation.
+	ModeDryRun Mode = "dry-run"
+	// ModePrint prepares records for deterministic machine-readable output.
+	ModePrint Mode = "print"
+)
+
+const (
+	// StatusReady means validated records are ready but were not submitted.
+	StatusReady Status = "ready"
+	// StatusSubmitted means a new Registry pull request was created.
+	StatusSubmitted Status = "submitted"
+	// StatusExistingSubmission means an exact open Registry pull request was found.
+	StatusExistingSubmission Status = "existing-submission"
+	// StatusAlreadyPublished means the release records already exist in the Registry.
+	StatusAlreadyPublished Status = "already-published"
+)

--- a/pkg/module/service.go
+++ b/pkg/module/service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 
-	barnpublish "github.com/MontFerret/barn/pkg/publish"
-
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
@@ -63,11 +61,11 @@ func (s *Service) Create(ctx context.Context, options scaffold.Options) (*scaffo
 	return s.scaffolder.Create(ctx, options)
 }
 
-// Publish prepares validated Barn registration records from a local release.
-func (s *Service) Publish(ctx context.Context, options modulepublish.Options) (*barnpublish.Result, error) {
+// Publish prepares and optionally submits a module release to the Registry.
+func (s *Service) Publish(ctx context.Context, options modulepublish.Options) (*modulepublish.Result, error) {
 	if s.publisher == nil {
 		return nil, errors.New("module publisher is not configured")
 	}
 
-	return s.publisher.Prepare(ctx, options)
+	return s.publisher.Publish(ctx, options)
 }

--- a/pkg/module/service_test.go
+++ b/pkg/module/service_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	barnpublish "github.com/MontFerret/barn/pkg/publish"
-
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
@@ -23,7 +21,7 @@ type fakeLifecycle struct {
 	info           *discovery.ModuleInfo
 	installResult  *install.Result
 	createResult   *scaffold.Result
-	publishResult  *barnpublish.Result
+	publishResult  *modulepublish.Result
 }
 
 func (f *fakeLifecycle) Search(_ context.Context, query string) ([]discovery.SearchResult, error) {
@@ -46,7 +44,7 @@ func (f *fakeLifecycle) Create(_ context.Context, options scaffold.Options) (*sc
 	return f.createResult, nil
 }
 
-func (f *fakeLifecycle) Prepare(_ context.Context, options modulepublish.Options) (*barnpublish.Result, error) {
+func (f *fakeLifecycle) Publish(_ context.Context, options modulepublish.Options) (*modulepublish.Result, error) {
 	f.publishOptions = options
 	return f.publishResult, nil
 }
@@ -57,7 +55,7 @@ func TestServiceDelegatesToWorkflowComponents(t *testing.T) {
 		info:          &discovery.ModuleInfo{Name: "acme/widget"},
 		installResult: &install.Result{ID: "acme/widget"},
 		createResult:  &scaffold.Result{Directory: "widget"},
-		publishResult: &barnpublish.Result{Kind: barnpublish.NewModule},
+		publishResult: &modulepublish.Result{Status: modulepublish.StatusSubmitted},
 	}
 	service := NewService(lifecycle, lifecycle, lifecycle, lifecycle)
 	ctx := context.Background()

--- a/pkg/module/types.go
+++ b/pkg/module/types.go
@@ -3,8 +3,6 @@ package module
 import (
 	"context"
 
-	barnpublish "github.com/MontFerret/barn/pkg/publish"
-
 	"github.com/MontFerret/cli/v2/pkg/module/discovery"
 	"github.com/MontFerret/cli/v2/pkg/module/install"
 	modulepublish "github.com/MontFerret/cli/v2/pkg/module/publish"
@@ -28,8 +26,8 @@ type (
 		Create(context.Context, scaffold.Options) (*scaffold.Result, error)
 	}
 
-	// Publisher prepares a module release for publication.
+	// Publisher prepares and optionally submits a module release for publication.
 	Publisher interface {
-		Prepare(context.Context, modulepublish.Options) (*barnpublish.Result, error)
+		Publish(context.Context, modulepublish.Options) (*modulepublish.Result, error)
 	}
 )


### PR DESCRIPTION
This pull request adds new features and improvements to the `ferret mod publish` command, enhancing the module publishing workflow for the Ferret Registry. The main changes include support for dry-run and JSON output modes, improved user guidance and output formatting, and updates to the documentation and tests to reflect these enhancements.

**Enhancements to the `ferret mod publish` command:**

* Added support for `--dry-run` and `--print` flags, allowing users to validate a release without submitting it or to print deterministic Barn-relative records as JSON, respectively. These modes cannot be used together. [[1]](diffhunk://#diff-eb4533546010240a70cd5a88f5ae10976d9d51978be6aaba8e06bd294ce28708R18-R19) [[2]](diffhunk://#diff-eb4533546010240a70cd5a88f5ae10976d9d51978be6aaba8e06bd294ce28708L188-R240) [[3]](diffhunk://#diff-bb95e0fb7d6a953396a1b094cefdf3a07711375d81dabc673e3021671f9d5278R4-R36) [[4]](diffhunk://#diff-bb95e0fb7d6a953396a1b094cefdf3a07711375d81dabc673e3021671f9d5278L106-R191)
* Improved output formatting and progress reporting, including clearer messages for validation, preparation, submission, and handling of already published or existing submissions.

**Documentation updates:**

* Expanded the `README.md` with detailed instructions for publishing modules, including the new flags, GitHub authentication requirements, and workflow clarifications. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R217)

**Testing improvements:**

* Added and updated tests to cover new modes (`--dry-run`, `--print`), output expectations, error handling for conflicting flags, and various publication scenarios.
* Refactored test fakes and imports to align with the new `modulepublish.Result` structure and usage. [[1]](diffhunk://#diff-1c50447b7c8faba1958434f8058f4a974db67904dda61e5c03d0191d1def3b51L6-L7) [[2]](diffhunk://#diff-1c50447b7c8faba1958434f8058f4a974db67904dda61e5c03d0191d1def3b51L19-R21) [[3]](diffhunk://#diff-1c50447b7c8faba1958434f8058f4a974db67904dda61e5c03d0191d1def3b51L61-R62) [[4]](diffhunk://#diff-06ed19e79f44d84c7140589c8e0caac6aca1d1f55e637420331ea2e62b72991bL6-L7) [[5]](diffhunk://#diff-06ed19e79f44d84c7140589c8e0caac6aca1d1f55e637420331ea2e62b72991bL32-R30) [[6]](diffhunk://#diff-ce5785cf966858e90acf7be8b7e1e65672813887b9347e626bd532d787f073d5R20) [[7]](diffhunk://#diff-f17ab9c413041fcd5a98bf59460d6b6cff3e57dc9677c18ee4b4ace9d111cac5L6-L7)

These changes make the publishing process more robust, user-friendly, and easier to automate or validate.