### PR TITLE
Add FQL migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ferret fmt script.fql       # Format source
 ferret build script.fql     # Compile to a bytecode artifact
 ferret inspect script.fql   # Print compiled program details
 ferret debug script.fql     # Start the interactive debugger
-ferret migrate              # Move a Ferret v1 Go application to the v2 compatibility API
+ferret migrate              # Migrate supported Ferret v1 Go and FQL source behavior
 ferret browser open         # Start a managed browser
 ferret config list          # Show configuration
 ferret mod search sqlite    # Search the Ferret module registry
@@ -120,12 +120,31 @@ Run `ferret migrate` from anywhere inside a Go module that embeds Ferret v1:
 ferret migrate
 ```
 
-The command rewrites the documented Ferret v1 imports to their Ferret v2
-compatibility packages, updates `go.mod` and `go.sum` as needed, and formats
-changed Go files. It is intentionally limited to the mechanical first stage of
-migration. It does not convert application logic to the native Ferret v2 API,
-rewrite generated or vendored code, or guess replacements for unsupported v1
-packages such as the former drivers packages.
+The command rewrites documented Ferret v1 imports to their Ferret v2
+compatibility packages and updates `go.mod` and `go.sum` only when an import was
+rewritten. It also finds lowercase `.fql` files in the containing Go module and
+preserves v1's implicit result for a final top-level `FOR` by returning it
+explicitly:
+
+```fql
+// Before
+FOR item IN 1..3
+    RETURN item
+```
+
+```fql
+// After
+return for item in 1..3 {
+    return item
+}
+```
+
+Only a structurally recognized final top-level `FOR` without an explicit
+terminal `return` is changed. Nested, assigned, expression-contained,
+function-contained, non-final, and already-returned loops remain untouched.
+Changed FQL is canonically formatted; files needing only formatting remain
+byte-for-byte unchanged. A project with only FQL migrations does not run
+`go get` or change Go module dependencies.
 
 Preview the affected paths without changing the project, or print a unified
 diff for review:
@@ -135,9 +154,18 @@ ferret migrate --dry-run
 ferret migrate --print
 ```
 
-Unsupported and generated-file imports are reported as manual follow-up. If a
-project vendors dependencies, run `go mod vendor` after reviewing and applying
-the migration.
+The source scan excludes `vendor`, `testdata`, `node_modules`, hidden and
+underscore-prefixed directories, and nested Go modules. Malformed FQL is left
+unchanged and reported with its first useful diagnostic and line while other
+files continue to migrate. Unsupported and generated-file imports are also
+reported as manual follow-up.
+
+Migration is intentionally limited to documented mechanical changes. It does
+not translate arbitrary v1 APIs or application logic, rewrite generated Go
+files or files under excluded directories, or guess replacements for
+unsupported v1 packages such as the former drivers packages. If a project
+vendors dependencies, run `go mod vendor` after reviewing and applying the
+migration.
 
 ## Module lifecycle
 

--- a/cmd/internal/migrate/command.go
+++ b/cmd/internal/migrate/command.go
@@ -18,10 +18,12 @@ const (
 func New(store *config.Store, service Service) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "migrate",
-		Short: "Migrate a Ferret v1 Go application to the v2 compatibility API",
-		Long: "Migrate the containing Go module from Ferret v1 imports to the Ferret v2 compatibility API.\n\n" +
-			"The command performs only documented mechanical import and dependency changes. " +
-			"It does not convert application logic to the native Ferret v2 API.",
+		Short: "Migrate supported Ferret v1 Go and FQL source behavior",
+		Long: "Migrate the containing Go module from supported Ferret v1 Go imports and FQL source behavior to Ferret v2.\n\n" +
+			"FQL migration returns and canonically formats a structurally recognized final top-level FOR. " +
+			"Malformed FQL is left unchanged and reported for manual follow-up.\n\n" +
+			"The command performs only documented mechanical import, dependency, and source changes. " +
+			"It does not convert application logic or arbitrary APIs to native Ferret v2 equivalents.",
 		Args: cobra.NoArgs,
 		PreRun: func(command *cobra.Command, _ []string) {
 			store.BindFlags(command)

--- a/cmd/internal/migrate/command_test.go
+++ b/cmd/internal/migrate/command_test.go
@@ -16,8 +16,10 @@ import (
 func TestMigrateCommandAppliesAndRendersMigration(t *testing.T) {
 	service := &fakeMigrationService{result: &migration.Result{
 		ScannedFiles:        4,
+		ScannedFQLFiles:     2,
 		UpdatedImports:      2,
 		FormattedFiles:      1,
+		MigratedFQLFiles:    1,
 		DependenciesChanged: true,
 		Applied:             true,
 		Changes: []migration.Change{
@@ -34,11 +36,13 @@ func TestMigrateCommandAppliesAndRendersMigration(t *testing.T) {
 	for _, expected := range []string{
 		"Ferret v1 → v2 compatibility migration",
 		"✓ Scanned 4 Go files",
+		"✓ Scanned 2 FQL files",
 		"  go.mod",
 		"  main.go",
 		"✓ Updated 2 Ferret imports",
 		"✓ Updated Go module dependencies",
 		"✓ Formatted 1 Go file",
+		"✓ Migrated and formatted 1 FQL file",
 		"Migration completed.",
 	} {
 		if !strings.Contains(stdout, expected) {
@@ -55,7 +59,9 @@ func TestMigrateCommandAppliesAndRendersMigration(t *testing.T) {
 
 func TestMigrateCommandDryRunListsFilesWithoutApplying(t *testing.T) {
 	service := &fakeMigrationService{result: &migration.Result{
-		ScannedFiles: 3,
+		ScannedFiles:     3,
+		ScannedFQLFiles:  1,
+		MigratedFQLFiles: 1,
 		Changes: []migration.Change{
 			{Path: "go.mod"},
 			{Path: "internal/app.go"},
@@ -67,7 +73,14 @@ func TestMigrateCommandDryRunListsFilesWithoutApplying(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, expected := range []string{"Would update:", "  go.mod", "  internal/app.go", "No files changed."} {
+	for _, expected := range []string{
+		"✓ Scanned 1 FQL file",
+		"✓ Found 1 supported FQL source migration",
+		"Would update:",
+		"  go.mod",
+		"  internal/app.go",
+		"No files changed.",
+	} {
 		if !strings.Contains(stdout, expected) {
 			t.Fatalf("expected stdout to contain %q:\n%s", expected, stdout)
 		}
@@ -82,13 +95,14 @@ func TestMigrateCommandDryRunListsFilesWithoutApplying(t *testing.T) {
 
 func TestMigrateCommandPrintsDeterministicUnifiedDiffOnlyOnStdout(t *testing.T) {
 	service := &fakeMigrationService{result: &migration.Result{
-		ScannedFiles: 1,
+		ScannedFQLFiles:  1,
+		MigratedFQLFiles: 1,
 		Changes: []migration.Change{
 			{
-				Path:         "main.go",
+				Path:         "query.fql",
 				BeforeExists: true,
-				Before:       []byte("package main\n\nvar version = 1\n"),
-				After:        []byte("package main\n\nvar version = 2\n"),
+				Before:       []byte("FOR x IN 1..3\n    RETURN x\n"),
+				After:        []byte("return for x in 1..3 {\n    return x\n}"),
 			},
 		},
 	}}
@@ -98,14 +112,15 @@ func TestMigrateCommandPrintsDeterministicUnifiedDiffOnlyOnStdout(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	want := "--- a/main.go\n" +
-		"+++ b/main.go\n" +
-		"@@ -1,4 +1,4 @@\n" +
-		" package main\n" +
-		" \n" +
-		"-var version = 1\n" +
-		"+var version = 2\n" +
-		" \n"
+	want := "--- a/query.fql\n" +
+		"+++ b/query.fql\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		"-FOR x IN 1..3\n" +
+		"-    RETURN x\n" +
+		"-\n" +
+		"+return for x in 1..3 {\n" +
+		"+    return x\n" +
+		"+}\n"
 	if stdout != want {
 		t.Fatalf("unexpected diff:\n%s", stdout)
 	}
@@ -126,10 +141,10 @@ func TestMigrateCommandRendersManualAndVendorWarnings(t *testing.T) {
 		Changes:        []migration.Change{{Path: "main.go"}},
 		ManualActions: []migration.ManualAction{
 			{
-				Path:       "generated.go",
-				Line:       4,
-				ImportPath: "github.com/MontFerret/ferret/pkg/runtime",
-				Reason:     "generated file was not modified",
+				Path:   "generated.go",
+				Line:   4,
+				Detail: "github.com/MontFerret/ferret/pkg/runtime",
+				Reason: "generated file was not modified",
 			},
 		},
 	}}

--- a/cmd/internal/migrate/render.go
+++ b/cmd/internal/migrate/render.go
@@ -14,6 +14,16 @@ func renderMigrationStatus(output io.Writer, result *migration.Result, mode migr
 	fmt.Fprintln(output, "Ferret v1 → v2 compatibility migration")
 	fmt.Fprintln(output, "✓ Found go.mod")
 	fmt.Fprintf(output, "✓ Scanned %d Go %s\n", result.ScannedFiles, migrationNoun(result.ScannedFiles, "file", "files"))
+	fmt.Fprintf(output, "✓ Scanned %d FQL %s\n", result.ScannedFQLFiles, migrationNoun(result.ScannedFQLFiles, "file", "files"))
+
+	if result.MigratedFQLFiles > 0 && mode != migration.ModeApply {
+		fmt.Fprintf(
+			output,
+			"✓ Found %d supported FQL source %s\n",
+			result.MigratedFQLFiles,
+			migrationNoun(result.MigratedFQLFiles, "migration", "migrations"),
+		)
+	}
 
 	if len(result.Changes) == 0 {
 		if len(result.ManualActions) == 0 {
@@ -75,6 +85,14 @@ func renderMigrationStatus(output io.Writer, result *migration.Result, mode migr
 			migrationNoun(result.FormattedFiles, "file", "files"),
 		)
 	}
+	if result.MigratedFQLFiles > 0 {
+		fmt.Fprintf(
+			output,
+			"✓ Migrated and formatted %d FQL %s\n",
+			result.MigratedFQLFiles,
+			migrationNoun(result.MigratedFQLFiles, "file", "files"),
+		)
+	}
 
 	if len(result.ManualActions) > 0 {
 		fmt.Fprintln(output, "Mechanical migration completed. Manual follow-up is still required.")
@@ -95,7 +113,7 @@ func renderMigrationWarnings(output io.Writer, result *migration.Result) {
 				"  %s:%d: %s (%s)\n",
 				action.Path,
 				action.Line,
-				action.ImportPath,
+				action.Detail,
 				action.Reason,
 			)
 		}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/MontFerret/contrib/modules/yaml v1.0.0-rc.14
 	github.com/MontFerret/ferret/v2 v2.0.0-alpha.46
 	github.com/MontFerret/specs v1.4.0
+	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/chzyer/readline v1.5.1
 	github.com/go-waitfor/waitfor v1.1.0
 	github.com/go-waitfor/waitfor-http v1.1.0
@@ -51,7 +52,6 @@ require (
 	github.com/andybalholm/cascadia v1.3.4 // indirect
 	github.com/antchfx/htmlquery v1.3.6 // indirect
 	github.com/antchfx/xpath v1.3.8 // indirect
-	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/corpix/uarand v0.2.0 // indirect

--- a/internal/migration/dependencies.go
+++ b/internal/migration/dependencies.go
@@ -18,7 +18,7 @@ func planDependencyChanges(
 	runner Runner,
 	versionProvider ferretVersionProvider,
 	project *migrationProject,
-	sources *sourcePlan,
+	sources *goSourcePlan,
 ) ([]plannedChange, bool, error) {
 	// Existing compat imports alone are not a migration and must not trigger dependency cleanup or upgrades.
 	if sources.UpdatedImports == 0 {

--- a/internal/migration/fql_source.go
+++ b/internal/migration/fql_source.go
@@ -1,0 +1,326 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/formatter"
+	"github.com/MontFerret/ferret/v2/pkg/parser"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func planFQLSourceChanges(ctx context.Context, project *migrationProject) (*fqlSourcePlan, error) {
+	result := &fqlSourcePlan{ScannedFiles: len(project.FQLFiles)}
+
+	for _, filename := range project.FQLFiles {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		snapshot, err := snapshotMigrationFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		relative, err := migrationRelativePath(project.Root, filename, "FQL")
+		if err != nil {
+			return nil, err
+		}
+
+		src := source.New(relative, string(snapshot.Data))
+		migration, err := migrateFQLSource(src)
+		if err != nil {
+			result.ManualActions = append(result.ManualActions, fqlManualAction(relative, src, err))
+
+			continue
+		}
+
+		if !migration.Changed {
+			continue
+		}
+
+		result.Changes = append(result.Changes, plannedChange{
+			change: Change{
+				Path:         relative,
+				Before:       snapshot.Data,
+				After:        migration.Data,
+				BeforeExists: true,
+			},
+			before: snapshot,
+			mode:   snapshot.Mode,
+		})
+		result.MigratedFiles++
+	}
+
+	sortManualActions(result.ManualActions)
+
+	return result, nil
+}
+
+func migrateFQLSource(src *source.Source) (fqlMigrationResult, error) {
+	if !utf8.ValidString(src.Content()) {
+		return fqlMigrationResult{}, fmt.Errorf("parse Ferret source: source is not valid UTF-8")
+	}
+
+	program, err := parseFQLSource(src)
+	if err != nil {
+		return fqlMigrationResult{}, err
+	}
+
+	body := program.Body()
+	if body == nil || body.BodyExpression() != nil {
+		return fqlMigrationResult{}, nil
+	}
+
+	statements := body.AllBodyStatement()
+	if len(statements) == 0 {
+		return fqlMigrationResult{}, nil
+	}
+
+	loop := statements[len(statements)-1].ForExpression()
+	if loop == nil || loop.GetStart() == nil {
+		return fqlMigrationResult{}, nil
+	}
+
+	migrated, err := rewriteFinalFQLFor(src.Content(), loop)
+	if err != nil {
+		return fqlMigrationResult{}, err
+	}
+
+	formatted, err := formatMigratedFQLSource(source.New(src.Name(), migrated))
+	if err != nil {
+		return fqlMigrationResult{}, err
+	}
+
+	return fqlMigrationResult{Data: formatted, Changed: true}, nil
+}
+
+func rewriteFinalFQLFor(content string, loop fql.IForExpressionContext) (string, error) {
+	start, ok := fqlByteOffset(content, loop.GetStart().GetStart())
+	if !ok {
+		return "", fmt.Errorf("locate final top-level FOR in Ferret source")
+	}
+
+	if loop.OpenBrace() != nil {
+		return content[:start] + "return " + content[start:], nil
+	}
+
+	headerStop := -1
+	if header := loop.ForExpressionSource(); header != nil && header.GetStop() != nil {
+		headerStop = header.GetStop().GetStop()
+	} else if header := loop.Expression(); header != nil && header.GetStop() != nil {
+		headerStop = header.GetStop().GetStop()
+	}
+
+	if headerStop < 0 || loop.GetStop() == nil {
+		return "", fmt.Errorf("locate final top-level FOR boundaries in Ferret source")
+	}
+
+	headerEnd, ok := fqlByteOffset(content, headerStop+1)
+	if !ok {
+		return "", fmt.Errorf("locate final top-level FOR header in Ferret source")
+	}
+
+	loopEnd, ok := fqlByteOffset(content, loop.GetStop().GetStop()+1)
+	if !ok || headerEnd > loopEnd {
+		return "", fmt.Errorf("locate final top-level FOR body in Ferret source")
+	}
+
+	return content[:start] + "return " + content[start:headerEnd] + " {" +
+		content[headerEnd:loopEnd] + "\n}" + content[loopEnd:], nil
+}
+
+func parseFQLSource(src *source.Source) (program *fql.ProgramContext, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			program = nil
+			err = fmt.Errorf("parse Ferret source: %v", recovered)
+		}
+	}()
+
+	handler := parserd.NewErrorHandler(src, 10)
+	history := parserd.NewTokenHistory(64)
+	p := parser.New(src.Content(), func(stream antlr.TokenStream) antlr.TokenStream {
+		return parserd.NewTrackingTokenStream(stream, history)
+	})
+	p.RemoveErrorListeners()
+	p.AddErrorListener(parserd.NewErrorListener(src, handler, history))
+
+	program = p.Program()
+	if handler.HasErrors() {
+		return nil, fmt.Errorf("parse Ferret source: %w", handler.Errors().First())
+	}
+
+	return program, nil
+}
+
+func formatMigratedFQLSource(src *source.Source) (data []byte, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			data = nil
+			err = fmt.Errorf("format migrated Ferret source: %v", recovered)
+		}
+	}()
+
+	// Alpha.46 token positions count runes while its formatter slices bytes. ASCII placeholders make
+	// those positions byte-safe; the exact runes are restored before the formatted source is validated.
+	protected, replacements := protectFQLNonASCII(src.Content())
+
+	var output bytes.Buffer
+	if err := formatter.New().Format(&output, source.New(src.Name(), protected)); err != nil {
+		return nil, fmt.Errorf("format migrated Ferret source: %w", err)
+	}
+
+	restored, err := restoreFQLNonASCII(output.String(), replacements)
+	if err != nil {
+		return nil, fmt.Errorf("format migrated Ferret source: %w", err)
+	}
+
+	formatted := []byte(restored)
+	if !utf8.Valid(formatted) || !slices.Equal(nonASCIISequence(src.Content()), nonASCIISequence(restored)) {
+		return nil, fmt.Errorf("format migrated Ferret source: formatter did not preserve non-ASCII source text")
+	}
+
+	if _, err := parseFQLSource(source.New(src.Name(), string(formatted))); err != nil {
+		return nil, fmt.Errorf("validate formatted Ferret source: %w", err)
+	}
+
+	return formatted, nil
+}
+
+type fqlNonASCIIReplacement struct {
+	marker string
+	value  rune
+}
+
+func protectFQLNonASCII(content string) (string, []fqlNonASCIIReplacement) {
+	if utf8.RuneCountInString(content) == len(content) {
+		return content, nil
+	}
+
+	prefix := "ferretmigrateunicodeplaceholder"
+	for strings.Contains(content, prefix) {
+		prefix += "x"
+	}
+
+	var protected strings.Builder
+	protected.Grow(len(content))
+
+	var replacements []fqlNonASCIIReplacement
+	for _, r := range content {
+		if r < utf8.RuneSelf {
+			protected.WriteRune(r)
+			continue
+		}
+
+		marker := prefix + strconv.Itoa(len(replacements)) + "x"
+		protected.WriteString(marker)
+		replacements = append(replacements, fqlNonASCIIReplacement{marker: marker, value: r})
+	}
+
+	return protected.String(), replacements
+}
+
+func restoreFQLNonASCII(content string, replacements []fqlNonASCIIReplacement) (string, error) {
+	for _, replacement := range replacements {
+		if strings.Count(content, replacement.marker) != 1 {
+			return "", fmt.Errorf("formatter did not preserve non-ASCII placeholder")
+		}
+
+		content = strings.Replace(content, replacement.marker, string(replacement.value), 1)
+	}
+
+	return content, nil
+}
+
+func nonASCIISequence(content string) []rune {
+	var result []rune
+	for _, r := range content {
+		if r >= utf8.RuneSelf {
+			result = append(result, r)
+		}
+	}
+
+	return result
+}
+
+func fqlManualAction(path string, src *source.Source, err error) ManualAction {
+	action := ManualAction{
+		Path:   path,
+		Detail: err.Error(),
+		Reason: "Ferret source could not be migrated safely; file was not modified",
+		Line:   1,
+	}
+
+	var diagnostic *diagnostics.Diagnostic
+	if !errors.As(err, &diagnostic) {
+		return action
+	}
+
+	action.Detail = diagnostic.Message
+	for _, span := range diagnostic.Spans {
+		if !span.Main {
+			continue
+		}
+
+		byteSpan, ok := fqlByteSpan(src.Content(), span.Span)
+		if !ok {
+			return action
+		}
+
+		line, _ := src.LocationAt(byteSpan)
+		if line > 0 {
+			action.Line = line
+		}
+
+		return action
+	}
+
+	return action
+}
+
+func fqlByteSpan(content string, span source.Span) (source.Span, bool) {
+	start, ok := fqlByteOffset(content, span.Start)
+	if !ok {
+		return source.Span{}, false
+	}
+
+	end, ok := fqlByteOffset(content, span.End)
+	if !ok {
+		return source.Span{}, false
+	}
+
+	return source.Span{Start: start, End: end}, true
+}
+
+func fqlByteOffset(content string, runeOffset int) (int, bool) {
+	if runeOffset < 0 {
+		return 0, false
+	}
+
+	current := 0
+	for byteOffset := range content {
+		if current == runeOffset {
+			return byteOffset, true
+		}
+
+		current++
+	}
+
+	if current == runeOffset {
+		return len(content), true
+	}
+
+	return 0, false
+}

--- a/internal/migration/fql_source_test.go
+++ b/internal/migration/fql_source_test.go
@@ -1,0 +1,254 @@
+package migration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	ferret "github.com/MontFerret/ferret/v2"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func TestMigrateFQLSourceFinalTopLevelFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "final loop",
+			input: `FOR x IN 1..10
+    RETURN x`,
+			want: `return for x in 1..10 {
+    return x
+}`,
+		},
+		{
+			name: "statements before final loop",
+			input: `LET xs = 1..10
+FOR x IN xs
+    RETURN x`,
+			want: `let xs = 1..10
+return for x in xs {
+    return x
+}`,
+		},
+		{
+			name: "final while loop",
+			input: `VAR i = 0
+FOR WHILE i < 3
+    i += 1
+    RETURN i`,
+			want: `var i = 0
+return for while i < 3 {
+    i += 1
+    return i
+}`,
+		},
+		{
+			name: "nested loop wraps outer only",
+			input: `FOR x IN 1..10 {
+    FOR y IN 1..10 {
+        RETURN x * y
+    }
+}`,
+			want: `return for x in 1..10 {
+    for y in 1..10 {
+        return x * y
+    }
+}`,
+		},
+		{
+			name: "unicode before final loop uses byte offset",
+			input: `LET label = "привет"
+FOR x IN 1..3
+    RETURN { label, x }`,
+			want: `let label = "привет"
+return for x in 1..3 {
+    return { label, x }
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := migrateFQLSource(source.New("query.fql", test.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !result.Changed {
+				t.Fatal("expected source migration")
+			}
+
+			if got := string(result.Data); got != test.want {
+				t.Fatalf("unexpected migration:\nwant:\n%s\ngot:\n%s", test.want, got)
+			}
+		})
+	}
+}
+
+func TestMigrateFQLSourceLeavesOtherProgramsUnchanged(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "non-final loop",
+			input: `FOR x IN 1..10 {
+    PRINT(x)
+}
+RETURN 42`,
+		},
+		{
+			name: "already explicit loop result",
+			input: `RETURN FOR x IN 1..10 {
+    RETURN x
+}`,
+		},
+		{
+			name: "assigned loop",
+			input: `LET xs = (
+    FOR x IN 1..10 {
+        RETURN x
+    }
+)
+RETURN xs`,
+		},
+		{
+			name: "loop inside function",
+			input: `FUNC values() {
+    FOR x IN 1..10 {
+        RETURN x
+    }
+}
+RETURN values()`,
+		},
+		{
+			name:  "effect-only script",
+			input: "CLICK(button)\nWAITFOR EXISTS confirmation",
+		},
+		{
+			name:  "explicit return none",
+			input: "CLICK(button)\nRETURN NONE",
+		},
+		{
+			name: "FOR in string and comment",
+			input: `LET message = "FOR x IN xs RETURN x"
+// FOR foo IN bar RETURN foo`,
+		},
+		{
+			name:  "formatting alone is not migration",
+			input: "LET value = 1\nRETURN value",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := migrateFQLSource(source.New("query.fql", test.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if result.Changed || result.Data != nil {
+				t.Fatalf("unexpected migration: %#v", result)
+			}
+		})
+	}
+}
+
+func TestMigrateFQLSourcePreservesComments(t *testing.T) {
+	input := `// before final loop
+FOR x IN 1..3
+    // inside loop
+    RETURN x
+// after final loop`
+
+	result, err := migrateFQLSource(source.New("comments.fql", input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.Changed {
+		t.Fatal("expected source migration")
+	}
+
+	got := string(result.Data)
+	for _, comment := range []string{"// before final loop", "// inside loop", "// after final loop"} {
+		if !strings.Contains(got, comment) {
+			t.Fatalf("migration dropped %q:\n%s", comment, got)
+		}
+	}
+
+	if !strings.Contains(got, "return for x in 1..3") {
+		t.Fatalf("final loop was not returned:\n%s", got)
+	}
+}
+
+func TestMigrateFQLSourceReportsInvalidSource(t *testing.T) {
+	src := source.New("broken.fql", "LET ok = 1\nFOR x IN\n    RETURN x")
+	result, err := migrateFQLSource(src)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+
+	if result.Changed || result.Data != nil {
+		t.Fatalf("invalid source was changed: %#v", result)
+	}
+
+	action := fqlManualAction("broken.fql", src, err)
+	if action.Path != "broken.fql" || action.Line < 2 || action.Detail == "" ||
+		action.Reason != "Ferret source could not be migrated safely; file was not modified" {
+		t.Fatalf("unexpected manual action: %#v", action)
+	}
+}
+
+func TestMigrateFQLSourceReportsInvalidUTF8(t *testing.T) {
+	result, err := migrateFQLSource(source.New("broken.fql", string([]byte{'F', 'O', 'R', ' ', 0xff})))
+	if err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Changed || result.Data != nil {
+		t.Fatalf("invalid UTF-8 was changed: %#v", result)
+	}
+}
+
+func TestMigrateFQLSourceExecutesAndIsIdempotent(t *testing.T) {
+	first, err := migrateFQLSource(source.New("query.fql", "FOR x IN 1..3\n    RETURN x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := parseFQLSource(source.New("query.fql", string(first.Data))); err != nil {
+		t.Fatalf("migrated source does not parse: %v", err)
+	}
+
+	engine, err := ferret.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := engine.Close(); err != nil {
+			t.Errorf("close engine: %v", err)
+		}
+	})
+
+	output, err := engine.Run(context.Background(), source.New("query.fql", string(first.Data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(output.Content), "[1,2,3]"; got != want {
+		t.Fatalf("migrated result = %s, want %s", got, want)
+	}
+
+	second, err := migrateFQLSource(source.New("query.fql", string(first.Data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if second.Changed || second.Data != nil {
+		t.Fatalf("second migration changed source: %#v", second)
+	}
+}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -139,9 +140,9 @@ func generatedButMalformed(
 	if len(result.ManualActions) != 2 {
 		t.Fatalf("expected two manual actions, got %#v", result.ManualActions)
 	}
-	if result.ManualActions[0].ImportPath != "github.com/MontFerret/ferret/pkg/runtime" ||
+	if result.ManualActions[0].Detail != "github.com/MontFerret/ferret/pkg/runtime" ||
 		result.ManualActions[0].Reason != "generated file was not modified" ||
-		result.ManualActions[1].ImportPath != "github.com/MontFerret/ferret/pkg/drivers/cdp" {
+		result.ManualActions[1].Detail != "github.com/MontFerret/ferret/pkg/drivers/cdp" {
 		t.Fatalf("unexpected manual actions: %#v", result.ManualActions)
 	}
 	if after := readMigrationFixture(t, filepath.Join(root, "generated.go")); after != generatedBefore {
@@ -555,6 +556,213 @@ import "github.com/MontFerret/ferret"
 	}
 }
 
+func TestMigratorAppliesPureFQLMigrationWithoutChangingDependencies(t *testing.T) {
+	root := writeMigrationFixture(t, `module example.com/app
+
+go 1.25.0
+`, map[string]string{
+		"main.go": "package app\n",
+		"query.fql": `FOR x IN 1..3
+    RETURN x`,
+	})
+	goModBefore := readMigrationFixture(t, filepath.Join(root, "go.mod"))
+	migrator, runner := newFixtureMigrator()
+
+	first, err := migrator.Migrate(context.Background(), Options{Directory: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !first.Applied || first.ScannedFQLFiles != 1 || first.MigratedFQLFiles != 1 ||
+		first.DependenciesChanged || runner.getCalls != 0 {
+		t.Fatalf("unexpected FQL migration result: %#v, get calls=%d", first, runner.getCalls)
+	}
+
+	if got := readMigrationFixture(t, filepath.Join(root, "query.fql")); got != `return for x in 1..3 {
+    return x
+}` {
+		t.Fatalf("unexpected migrated FQL:\n%s", got)
+	}
+
+	if got := readMigrationFixture(t, filepath.Join(root, "go.mod")); got != goModBefore {
+		t.Fatalf("pure FQL migration changed go.mod:\n%s", got)
+	}
+
+	second, err := migrator.Migrate(context.Background(), Options{Directory: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if second.Applied || second.MigratedFQLFiles != 0 || len(second.Changes) != 0 || runner.getCalls != 0 {
+		t.Fatalf("second migration was not a no-op: %#v, get calls=%d", second, runner.getCalls)
+	}
+}
+
+func TestMigratorAppliesGoAndFQLChangesTogether(t *testing.T) {
+	root := writeMigrationFixture(t, `module example.com/app
+
+go 1.25.0
+
+require github.com/MontFerret/ferret v1.0.0
+`, map[string]string{
+		"main.go": `package app
+import "github.com/MontFerret/ferret"
+`,
+		"query.fql": `LET values = 1..3
+FOR value IN values
+    RETURN value`,
+	})
+	migrator, runner := newFixtureMigrator()
+
+	result, err := migrator.Migrate(context.Background(), Options{Directory: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.Applied || result.UpdatedImports != 1 || result.MigratedFQLFiles != 1 ||
+		!result.DependenciesChanged || runner.getCalls != 1 {
+		t.Fatalf("unexpected mixed migration result: %#v, get calls=%d", result, runner.getCalls)
+	}
+
+	paths := make([]string, len(result.Changes))
+	for index, change := range result.Changes {
+		paths[index] = change.Path
+	}
+
+	wantPaths := []string{"go.mod", "go.sum", "main.go", "query.fql"}
+	if !slices.Equal(paths, wantPaths) {
+		t.Fatalf("mixed migration paths = %v, want %v", paths, wantPaths)
+	}
+}
+
+func TestMigratorFQLDiscoveryPreservesExistingExclusions(t *testing.T) {
+	root := writeMigrationFixture(t, `module example.com/app
+
+go 1.25.0
+`, map[string]string{
+		"main.go":                       "package app\n",
+		"query.fql":                     "FOR x IN 1..3 RETURN x",
+		"vendor/dependency/vendor.fql":  "FOR x IN 1..3 RETURN x",
+		"testdata/fixture.fql":          "FOR x IN 1..3 RETURN x",
+		"node_modules/module/query.fql": "FOR x IN 1..3 RETURN x",
+		".hidden/query.fql":             "FOR x IN 1..3 RETURN x",
+		"_generated/query.fql":          "FOR x IN 1..3 RETURN x",
+		"upper.FQL":                     "FOR x IN 1..3 RETURN x",
+		"nested/go.mod":                 "module example.com/nested\n\ngo 1.25.0\n",
+		"nested/query.fql":              "FOR x IN 1..3 RETURN x",
+	})
+	excluded := []string{
+		"vendor/dependency/vendor.fql",
+		"testdata/fixture.fql",
+		"node_modules/module/query.fql",
+		".hidden/query.fql",
+		"_generated/query.fql",
+		"upper.FQL",
+		"nested/query.fql",
+	}
+	before := make(map[string]string, len(excluded))
+	for _, path := range excluded {
+		before[path] = readMigrationFixture(t, filepath.Join(root, path))
+	}
+
+	migrator, _ := newFixtureMigrator()
+	result, err := migrator.Migrate(context.Background(), Options{Directory: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.ScannedFQLFiles != 1 || result.MigratedFQLFiles != 1 {
+		t.Fatalf("unexpected FQL discovery result: %#v", result)
+	}
+
+	for _, path := range excluded {
+		if got := readMigrationFixture(t, filepath.Join(root, path)); got != before[path] {
+			t.Fatalf("excluded FQL file %s changed:\n%s", path, got)
+		}
+	}
+}
+
+func TestMigratorReportsMalformedFQLAndContinues(t *testing.T) {
+	root := writeMigrationFixture(t, `module example.com/app
+
+go 1.25.0
+`, map[string]string{
+		"main.go":   "package app\n",
+		"valid.fql": "FOR x IN 1..3 RETURN x",
+		"broken.fql": `LET ok = 1
+FOR x IN
+    RETURN x`,
+	})
+	brokenBefore := readMigrationFixture(t, filepath.Join(root, "broken.fql"))
+	migrator, _ := newFixtureMigrator()
+
+	result, err := migrator.Migrate(context.Background(), Options{Directory: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.Applied || result.ScannedFQLFiles != 2 || result.MigratedFQLFiles != 1 ||
+		len(result.ManualActions) != 1 {
+		t.Fatalf("unexpected malformed FQL result: %#v", result)
+	}
+
+	action := result.ManualActions[0]
+	if action.Path != "broken.fql" || action.Line < 2 || action.Detail == "" {
+		t.Fatalf("unexpected manual action: %#v", action)
+	}
+
+	if got := readMigrationFixture(t, filepath.Join(root, "broken.fql")); got != brokenBefore {
+		t.Fatalf("malformed FQL changed:\n%s", got)
+	}
+
+	if got := readMigrationFixture(t, filepath.Join(root, "valid.fql")); !strings.HasPrefix(got, "return for") {
+		t.Fatalf("valid FQL was not migrated:\n%s", got)
+	}
+}
+
+func TestMigratorFQLDryRunDoesNotWriteAndPreservesModeOnApply(t *testing.T) {
+	root := writeMigrationFixture(t, `module example.com/app
+
+go 1.25.0
+`, map[string]string{
+		"main.go":   "package app\n",
+		"query.fql": "FOR x IN 1..3 RETURN x",
+	})
+	path := filepath.Join(root, "query.fql")
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := readMigrationFixture(t, path)
+	migrator, _ := newFixtureMigrator()
+
+	preview, err := migrator.Migrate(context.Background(), Options{Directory: root, Mode: ModeDryRun})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if preview.Applied || preview.MigratedFQLFiles != 1 || readMigrationFixture(t, path) != before {
+		t.Fatalf("dry run mutated FQL: %#v", preview)
+	}
+
+	applied, err := migrator.Migrate(context.Background(), Options{Directory: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !applied.Applied || applied.MigratedFQLFiles != 1 {
+		t.Fatalf("unexpected applied result: %#v", applied)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("FQL mode = %o, want 600", got)
+	}
+}
+
 func TestMigratorRejectsMissingOrMalformedProjects(t *testing.T) {
 	t.Run("missing go.mod", func(t *testing.T) {
 		migrator, _ := newFixtureMigrator()
@@ -600,7 +808,7 @@ func TestListMigrationFilesDoesNotHideEnumerationFailures(t *testing.T) {
 func TestCommitMigrationChangesRollsBackEarlierFiles(t *testing.T) {
 	root := t.TempDir()
 	firstPath := filepath.Join(root, "first.go")
-	secondPath := filepath.Join(root, "second.go")
+	secondPath := filepath.Join(root, "query.fql")
 	if err := os.WriteFile(firstPath, []byte("first-before"), 0o640); err != nil {
 		t.Fatal(err)
 	}
@@ -617,7 +825,7 @@ func TestCommitMigrationChangesRollsBackEarlierFiles(t *testing.T) {
 			mode:   first.Mode,
 		},
 		{
-			change: Change{Path: "second.go", Before: second.Data, After: []byte("second-after"), BeforeExists: true},
+			change: Change{Path: "query.fql", Before: second.Data, After: []byte("second-after"), BeforeExists: true},
 			before: second,
 			mode:   second.Mode,
 		},
@@ -668,12 +876,44 @@ var Value%d = values.NewInt(%d)
 	b.ResetTimer()
 
 	for range b.N {
-		result, err := planSourceChanges(context.Background(), project)
+		result, err := planGoSourceChanges(context.Background(), project)
 		if err != nil {
 			b.Fatal(err)
 		}
+
 		if result.UpdatedImports != len(files) {
 			b.Fatalf("expected %d imports, got %d", len(files), result.UpdatedImports)
+		}
+	}
+}
+
+func BenchmarkPlanFQLSourceChanges(b *testing.B) {
+	root := b.TempDir()
+	files := make([]string, 100)
+	for index := range files {
+		filename := filepath.Join(root, fmt.Sprintf("query_%03d.fql", index))
+		source := fmt.Sprintf(`LET seed = %d
+FOR value IN 1..100 {
+    FILTER value > seed
+    RETURN value * 2
+}`, index)
+		if err := os.WriteFile(filename, []byte(source), 0o644); err != nil {
+			b.Fatal(err)
+		}
+		files[index] = filename
+	}
+
+	project := &migrationProject{Root: root, FQLFiles: files}
+	b.ResetTimer()
+
+	for range b.N {
+		result, err := planFQLSourceChanges(context.Background(), project)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if result.MigratedFiles != len(files) {
+			b.Fatalf("expected %d FQL migrations, got %d", len(files), result.MigratedFiles)
 		}
 	}
 }

--- a/internal/migration/project.go
+++ b/internal/migration/project.go
@@ -65,19 +65,21 @@ func discoverMigrationProject(ctx context.Context, runner Runner, directory stri
 		GoModPath:  discovered.GoModPath,
 		GoSumPath:  discovered.GoSumPath,
 		GoModFile:  parsed,
-		GoFiles:    files,
+		GoFiles:    files.Go,
+		FQLFiles:   files.FQL,
 		GoMod:      goMod,
 		GoSum:      goSum,
 	}, nil
 }
 
-func listMigrationFiles(ctx context.Context, runner Runner, root string) ([]string, error) {
+func listMigrationFiles(ctx context.Context, runner Runner, root string) (migrationFiles, error) {
 	output, err := runner.Run(ctx, root, "list", "-e", "-json", "-mod=readonly", "./...")
 	if err != nil {
-		return nil, fmt.Errorf("enumerate project Go files: %w", err)
+		return migrationFiles{}, fmt.Errorf("enumerate project Go files: %w", err)
 	}
 
-	files := make(map[string]struct{})
+	goFiles := make(map[string]struct{})
+	fqlFiles := make(map[string]struct{})
 	decoder := json.NewDecoder(bytes.NewReader(output))
 
 	for {
@@ -87,7 +89,7 @@ func listMigrationFiles(ctx context.Context, runner Runner, root string) ([]stri
 				break
 			}
 
-			return nil, fmt.Errorf("decode project package metadata: %w", err)
+			return migrationFiles{}, fmt.Errorf("decode project package metadata: %w", err)
 		}
 
 		packageFiles := append([]string{}, pkg.GoFiles...)
@@ -99,7 +101,7 @@ func listMigrationFiles(ctx context.Context, runner Runner, root string) ([]stri
 
 		if pkg.Error != nil && pkg.Error.Err != "" &&
 			(pkg.Module == nil || pkg.Dir == "" || len(packageFiles) == 0) {
-			return nil, fmt.Errorf("enumerate package %q: %s", pkg.ImportPath, pkg.Error.Err)
+			return migrationFiles{}, fmt.Errorf("enumerate package %q: %s", pkg.ImportPath, pkg.Error.Err)
 		}
 
 		if pkg.Module == nil || !pkg.Module.Main || pkg.Dir == "" {
@@ -111,25 +113,39 @@ func listMigrationFiles(ctx context.Context, runner Runner, root string) ([]stri
 				continue
 			}
 
-			files[filepath.Join(pkg.Dir, name)] = struct{}{}
+			goFiles[filepath.Join(pkg.Dir, name)] = struct{}{}
 		}
 	}
 
-	if err := walkMigrationFiles(ctx, root, files); err != nil {
-		return nil, err
+	if err := walkMigrationFiles(ctx, root, goFiles, fqlFiles); err != nil {
+		return migrationFiles{}, err
 	}
 
-	result := make([]string, 0, len(files))
-	for filename := range files {
-		result = append(result, filename)
+	result := migrationFiles{
+		Go:  make([]string, 0, len(goFiles)),
+		FQL: make([]string, 0, len(fqlFiles)),
 	}
 
-	sort.Strings(result)
+	for filename := range goFiles {
+		result.Go = append(result.Go, filename)
+	}
+
+	for filename := range fqlFiles {
+		result.FQL = append(result.FQL, filename)
+	}
+
+	sort.Strings(result.Go)
+	sort.Strings(result.FQL)
 
 	return result, nil
 }
 
-func walkMigrationFiles(ctx context.Context, root string, files map[string]struct{}) error {
+func walkMigrationFiles(
+	ctx context.Context,
+	root string,
+	goFiles map[string]struct{},
+	fqlFiles map[string]struct{},
+) error {
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -159,14 +175,17 @@ func walkMigrationFiles(ctx context.Context, root string, files map[string]struc
 			return nil
 		}
 
-		if filepath.Ext(entry.Name()) == ".go" {
-			files[path] = struct{}{}
+		switch filepath.Ext(entry.Name()) {
+		case ".go":
+			goFiles[path] = struct{}{}
+		case ".fql":
+			fqlFiles[path] = struct{}{}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("scan project Go files: %w", err)
+		return fmt.Errorf("scan project source files: %w", err)
 	}
 
 	return nil

--- a/internal/migration/source.go
+++ b/internal/migration/source.go
@@ -8,8 +8,6 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 )
@@ -23,8 +21,8 @@ var v1CompatibilityImports = map[string]string{
 	"github.com/MontFerret/ferret/pkg/runtime/values/types": "github.com/MontFerret/ferret/v2/compat/runtime/values/types",
 }
 
-func planSourceChanges(ctx context.Context, project *migrationProject) (*sourcePlan, error) {
-	result := &sourcePlan{ScannedFiles: len(project.GoFiles)}
+func planGoSourceChanges(ctx context.Context, project *migrationProject) (*goSourcePlan, error) {
+	result := &goSourcePlan{ScannedFiles: len(project.GoFiles)}
 
 	for _, filename := range project.GoFiles {
 		if err := ctx.Err(); err != nil {
@@ -52,14 +50,10 @@ func planSourceChanges(ctx context.Context, project *migrationProject) (*sourceP
 			return nil, fmt.Errorf("parse %s: %w", filename, err)
 		}
 
-		relative, err := filepath.Rel(project.Root, filename)
+		relative, err := migrationRelativePath(project.Root, filename, "Go")
 		if err != nil {
-			return nil, fmt.Errorf("resolve project-relative path for %s: %w", filename, err)
+			return nil, err
 		}
-		if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-			return nil, fmt.Errorf("refusing to migrate Go file outside project root: %s", filename)
-		}
-		relative = filepath.ToSlash(relative)
 
 		updated := 0
 		for _, spec := range file.Imports {
@@ -77,10 +71,10 @@ func planSourceChanges(ctx context.Context, project *migrationProject) (*sourceP
 				if isV1FerretImport(importPath) {
 					result.RemainingV1 = true
 					result.ManualActions = append(result.ManualActions, ManualAction{
-						Path:       relative,
-						ImportPath: importPath,
-						Reason:     "no documented v2 compatibility replacement",
-						Line:       fileSet.Position(spec.Pos()).Line,
+						Path:   relative,
+						Detail: importPath,
+						Reason: "no documented v2 compatibility replacement",
+						Line:   fileSet.Position(spec.Pos()).Line,
 					})
 				}
 
@@ -90,10 +84,10 @@ func planSourceChanges(ctx context.Context, project *migrationProject) (*sourceP
 			if generated {
 				result.RemainingV1 = true
 				result.ManualActions = append(result.ManualActions, ManualAction{
-					Path:       relative,
-					ImportPath: importPath,
-					Reason:     "generated file was not modified",
-					Line:       fileSet.Position(spec.Pos()).Line,
+					Path:   relative,
+					Detail: importPath,
+					Reason: "generated file was not modified",
+					Line:   fileSet.Position(spec.Pos()).Line,
 				})
 
 				continue
@@ -130,17 +124,7 @@ func planSourceChanges(ctx context.Context, project *migrationProject) (*sourceP
 		result.FormattedFiles++
 	}
 
-	sort.Slice(result.ManualActions, func(i, j int) bool {
-		if result.ManualActions[i].Path != result.ManualActions[j].Path {
-			return result.ManualActions[i].Path < result.ManualActions[j].Path
-		}
-
-		if result.ManualActions[i].Line != result.ManualActions[j].Line {
-			return result.ManualActions[i].Line < result.ManualActions[j].Line
-		}
-
-		return result.ManualActions[i].ImportPath < result.ManualActions[j].ImportPath
-	})
+	sortManualActions(result.ManualActions)
 
 	return result, nil
 }

--- a/internal/migration/source_paths.go
+++ b/internal/migration/source_paths.go
@@ -1,0 +1,35 @@
+package migration
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func migrationRelativePath(root, filename, kind string) (string, error) {
+	relative, err := filepath.Rel(root, filename)
+	if err != nil {
+		return "", fmt.Errorf("resolve project-relative path for %s: %w", filename, err)
+	}
+
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing to migrate %s file outside project root: %s", kind, filename)
+	}
+
+	return filepath.ToSlash(relative), nil
+}
+
+func sortManualActions(actions []ManualAction) {
+	sort.Slice(actions, func(i, j int) bool {
+		if actions[i].Path != actions[j].Path {
+			return actions[i].Path < actions[j].Path
+		}
+
+		if actions[i].Line != actions[j].Line {
+			return actions[i].Line < actions[j].Line
+		}
+
+		return actions[i].Detail < actions[j].Detail
+	})
+}

--- a/internal/migration/types.go
+++ b/internal/migration/types.go
@@ -34,12 +34,12 @@ type (
 		BeforeExists bool
 	}
 
-	// ManualAction identifies a v1 import that cannot be rewritten safely.
+	// ManualAction identifies project content that cannot be rewritten safely.
 	ManualAction struct {
-		Path       string
-		ImportPath string
-		Reason     string
-		Line       int
+		Path   string
+		Detail string
+		Reason string
+		Line   int
 	}
 
 	// Result describes the complete migration plan and its application status.
@@ -49,8 +49,10 @@ type (
 		Changes             []Change
 		ManualActions       []ManualAction
 		ScannedFiles        int
+		ScannedFQLFiles     int
 		UpdatedImports      int
 		FormattedFiles      int
+		MigratedFQLFiles    int
 		DependenciesChanged bool
 		VendorDetected      bool
 		Applied             bool
@@ -71,6 +73,7 @@ type (
 		GoSumPath  string
 		GoModFile  *modfile.File
 		GoFiles    []string
+		FQLFiles   []string
 		GoMod      fileSnapshot
 		GoSum      fileSnapshot
 	}
@@ -93,13 +96,30 @@ type (
 		Exists bool
 	}
 
-	sourcePlan struct {
+	goSourcePlan struct {
 		Changes        []plannedChange
 		ManualActions  []ManualAction
 		ScannedFiles   int
 		UpdatedImports int
 		FormattedFiles int
 		RemainingV1    bool
+	}
+
+	fqlSourcePlan struct {
+		Changes       []plannedChange
+		ManualActions []ManualAction
+		ScannedFiles  int
+		MigratedFiles int
+	}
+
+	fqlMigrationResult struct {
+		Data    []byte
+		Changed bool
+	}
+
+	migrationFiles struct {
+		Go  []string
+		FQL []string
 	}
 
 	goPackageInfo struct {

--- a/internal/migration/v1_to_v2.go
+++ b/internal/migration/v1_to_v2.go
@@ -28,7 +28,12 @@ func (planner *v1ToV2Planner) Plan(ctx context.Context, options Options) (*migra
 		return nil, err
 	}
 
-	sources, err := planSourceChanges(ctx, project)
+	goSources, err := planGoSourceChanges(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+
+	fqlSources, err := planFQLSourceChanges(ctx, project)
 	if err != nil {
 		return nil, err
 	}
@@ -38,13 +43,15 @@ func (planner *v1ToV2Planner) Plan(ctx context.Context, options Options) (*migra
 		planner.runner,
 		planner.ferretVersion,
 		project,
-		sources,
+		goSources,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	changes := append(append([]plannedChange{}, sources.Changes...), dependencies...)
+	changes := append([]plannedChange{}, goSources.Changes...)
+	changes = append(changes, fqlSources.Changes...)
+	changes = append(changes, dependencies...)
 	sort.Slice(changes, func(i, j int) bool {
 		return changes[i].change.Path < changes[j].change.Path
 	})
@@ -53,6 +60,10 @@ func (planner *v1ToV2Planner) Plan(ctx context.Context, options Options) (*migra
 	for index, change := range changes {
 		resultChanges[index] = change.change
 	}
+
+	manualActions := append([]ManualAction{}, goSources.ManualActions...)
+	manualActions = append(manualActions, fqlSources.ManualActions...)
+	sortManualActions(manualActions)
 
 	vendorDetected := false
 	if info, statErr := os.Stat(filepath.Join(project.Root, "vendor")); statErr == nil {
@@ -66,10 +77,12 @@ func (planner *v1ToV2Planner) Plan(ctx context.Context, options Options) (*migra
 			Root:                project.Root,
 			GoModPath:           project.GoModPath,
 			Changes:             resultChanges,
-			ManualActions:       sources.ManualActions,
-			ScannedFiles:        sources.ScannedFiles,
-			UpdatedImports:      sources.UpdatedImports,
-			FormattedFiles:      sources.FormattedFiles,
+			ManualActions:       manualActions,
+			ScannedFiles:        goSources.ScannedFiles,
+			ScannedFQLFiles:     fqlSources.ScannedFiles,
+			UpdatedImports:      goSources.UpdatedImports,
+			FormattedFiles:      goSources.FormattedFiles,
+			MigratedFQLFiles:    fqlSources.MigratedFiles,
 			DependenciesChanged: dependencyChanged,
 			VendorDetected:      vendorDetected,
 		},


### PR DESCRIPTION
- Introduced support for `.fql` source migration, including identification of unsupported files and automatic mechanical updates for final top-level `FOR` loops.
- Updated `ManualAction` structure, replacing `ImportPath` with `Detail` for clarity.
- Revised migration output to include scanned and migrated FQL files.
- Enhanced tests to validate mixed Go/FQL migrations, malformed FQL handling, and file exclusion rules.